### PR TITLE
Fix nginx config for serving HTTP assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.DS_Store
+.git
+.gitignore
+.vscode
+dist
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yarn install && yarn build
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 
-COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+COPY --from=build /usr/src/app/dist /opt/app-root/src
 USER 1001
 
 ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Copy the plugin files to the default nginx assets directory. The gets the serving of plugin assets over HTTP working (not HTTPS yet).

Also add .dockerignore file to avoid copying unnecessary files during build steps.