### PR TITLE
Add OLS action to pod Actions dropdown using redux

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -7,6 +7,13 @@
     }
   },
   {
+    "type": "console.action/provider",
+    "properties": {
+      "contextId": "core~v1~Pod",
+      "provider": { "$codeRef": "PodActionsProvider" }
+    }
+  },
+  {
     "type": "console.page/route",
     "properties": {
       "exact": true,
@@ -22,6 +29,13 @@
       "href": "/lightspeed",
       "perspective": "admin",
       "section": "home"
+    }
+  },
+  {
+    "type": "console.redux-reducer",
+    "properties": {
+      "scope": "ols",
+      "reducer": { "$codeRef": "OLSReducer" }
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-i18next": "^13.0.0",
+    "react-redux": "^7.2.2",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
     "style-loader": "^3.3.1",
@@ -71,7 +72,9 @@
     "description": "Add UI elements for interacting with OpenShift Lightspeed to the OpenShift web console.",
     "exposedModules": {
       "AlertActionsProvider": "./hooks/useAlertExtension",
-      "GeneralPage": "./components/GeneralPage"
+      "GeneralPage": "./components/GeneralPage",
+      "OLSReducer": "./redux-reducers",
+      "PodActionsProvider": "./hooks/usePodExtension"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import {
   Button,
   Form,
@@ -11,9 +13,11 @@ import {
   TextContent,
   Title,
 } from '@patternfly/react-core';
+
 import { cancellableFetch } from '../cancellable-fetch';
+import { State } from '../redux-reducers';
+
 import './general-page.css';
-import { useTranslation } from 'react-i18next';
 
 const QUERY_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/query';
 const QUERY_TIMEOUT = 60 * 1000;
@@ -69,7 +73,9 @@ const HistoryEntryWaiting = () => (
 const GeneralPage = () => {
   const { t } = useTranslation('plugin__lightspeed-console-plugin');
 
-  const [prompt, setPrompt] = React.useState('');
+  const initialPrompt = useSelector((s: State) => s.plugins?.ols.get('prompt'));
+
+  const [prompt, setPrompt] = React.useState(initialPrompt ?? '');
   const [history, setHistory] = React.useState<ChatEntry[]>([
     { text: t('Hello there. How can I help?'), who: 'ai' },
   ]);
@@ -97,7 +103,6 @@ const GeneralPage = () => {
 
       request()
         .then((response: QueryResponse) => {
-          console.warn(response);
           setHistory([
             ...newHistory,
             { text: response.response, who: 'ai' },
@@ -105,7 +110,6 @@ const GeneralPage = () => {
           setIsWaiting(false);
         })
         .catch((error) => {
-          console.warn(error);
           setHistory([
             ...newHistory,
             { error: error.toString(), text: undefined, who: 'ai' },

--- a/src/hooks/useAlertExtension.ts
+++ b/src/hooks/useAlertExtension.ts
@@ -10,10 +10,10 @@ const useAlertExtension: ExtensionHook<Array<Action>, AlertExtensionOptions> = (
     // TODO: Just a placeholder for now
     {
       id: 'monitoring-alert-list-item',
-      label: 'Lightspeed callback',
+      label: 'Ask OpenShift Lightspeed',
       cta: () => {
         const ruleName = options.alert?.rule?.name;
-        console.warn(`Lightspeed callback called for alert ${ruleName}`);
+        console.warn(`OpenShift Lightspeed callback called for alert ${ruleName}`);
       }
     },
   ]);

--- a/src/hooks/usePodExtension.ts
+++ b/src/hooks/usePodExtension.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { Action, ExtensionHook } from '@openshift-console/dynamic-plugin-sdk';
+
+import { setPromptText } from '../redux-actions';
+
+type PodExtensionOptions = {
+  pod?: any; // TODO
+};
+
+const usePodExtension: ExtensionHook<Array<Action>, PodExtensionOptions> = (options) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const [actions] = React.useState<Action[]>([
+    // TODO: Just a placeholder for now
+    {
+      id: 'core~v1~Pod',
+      label: 'Ask OpenShift Lightspeed',
+      cta: () => {
+        var prompt = `Tell me more about this pod.\n${JSON.stringify(options, null, 2)}`;
+        dispatch(setPromptText(prompt));
+        history.push('/lightspeed');
+      }
+    },
+  ]);
+  return [actions, true, null];
+};
+
+export default usePodExtension;

--- a/src/redux-actions.ts
+++ b/src/redux-actions.ts
@@ -1,0 +1,11 @@
+import { action, ActionType as Action } from 'typesafe-actions';
+
+export enum ActionType {
+  SetPromptText = 'setPromptText',
+}
+
+export const setPromptText = (prompt: string) => action(ActionType.SetPromptText, { prompt });
+
+const actions = { setPromptText };
+
+export type OLSAction = Action<typeof actions>;

--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -1,0 +1,27 @@
+import { Map as ImmutableMap } from 'immutable';
+
+import { ActionType, OLSAction } from './redux-actions';
+
+export type OLSState = ImmutableMap<string, any>;
+export type State = {
+  plugins: {
+    ols: OLSState;
+  }
+}
+
+const reducer = (state: OLSState, action: OLSAction): OLSState => {
+  if (!state) {
+    return ImmutableMap({ prompt: null });
+  }
+
+  switch (action.type) {
+    case ActionType.SetPromptText:
+      return state.set('prompt', action.payload.prompt);
+
+    default:
+      break;
+  }
+  return state;
+};
+
+export default reducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.12.13":
+"@babel/runtime@^7.12.13", "@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
@@ -509,6 +509,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/http-errors@*":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.4.tgz#7eb47726c391b7345a6ec35ad7f4de469cf5ba4f"
@@ -598,6 +606,16 @@
   integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.33"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.33.tgz#53c5564f03f1ded90904e3c90f77e4bd4dc20b15"
+  integrity sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-router-dom@^5.3.2":
   version "5.3.3"
@@ -3812,7 +3830,7 @@ history@^5.0.0, history@^5.3.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6463,6 +6481,11 @@ react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-redux@7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
@@ -6473,6 +6496,18 @@ react-redux@7.2.2:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.13.1"
+
+react-redux@^7.2.2:
+  version "7.2.9"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
+  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-router-dom-v5-compat@^6.11.2:
   version "6.22.0"
@@ -6665,6 +6700,13 @@ redux@4.0.1:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Adds an "Ask OpenShift Lightspeed" action to the Actions dropdown on the pod details page and to the kebab menu of the pods list page.

The callback is just a placeholder for now to show that the integration works.

Adds a redux store for the plugin, which allows passing data from the pod page to the OpenShift Lightspeed page.