### PR TITLE
OLS-247: Add proxy config so UI can hit the OLS API

### DIFF
--- a/charts/openshift-console-plugin/templates/consoleplugin.yaml
+++ b/charts/openshift-console-plugin/templates/consoleplugin.yaml
@@ -16,3 +16,5 @@ spec:
       namespace: {{ .Release.Namespace }}
       port: {{ .Values.plugin.port }}
       basePath: {{ .Values.plugin.basePath }}
+  proxy:
+    {{- toYaml .Values.plugin.proxy | nindent 4 }}

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -52,3 +52,12 @@ plugin:
         requests:
           cpu: 10m
           memory: 50Mi
+  proxy:
+    - alias: ols
+      authorization: None
+      endpoint:
+        service:
+          name: lightspeed-w-rag
+          namespace: openshift-lightspeed
+          port: 8443
+        type: Service


### PR DESCRIPTION
This currently uses `authorization: None`, but should be changed to
`authorization: UserToken` once the OLS API has auth set up.