### PR TITLE
Enable "Ask OpenShift Lightspeed" action on 4 more resource types

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -9,6 +9,20 @@
   {
     "type": "console.action/provider",
     "properties": {
+      "contextId": "batch~v1~CronJob",
+      "provider": { "$codeRef": "K8sResourceActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/provider",
+    "properties": {
+      "contextId": "apps~v1~DaemonSet",
+      "provider": { "$codeRef": "K8sResourceActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/provider",
+    "properties": {
       "contextId": "apps~v1~Deployment",
       "provider": { "$codeRef": "K8sResourceActionsProvider" }
     }
@@ -24,6 +38,20 @@
     "type": "console.action/provider",
     "properties": {
       "contextId": "core~v1~Pod",
+      "provider": { "$codeRef": "K8sResourceActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/provider",
+    "properties": {
+      "contextId": "apps~v1~ReplicaSet",
+      "provider": { "$codeRef": "K8sResourceActionsProvider" }
+    }
+  },
+  {
+    "type": "console.action/provider",
+    "properties": {
+      "contextId": "apps~v1~StatefulSet",
       "provider": { "$codeRef": "K8sResourceActionsProvider" }
     }
   },

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -254,7 +254,7 @@ const GeneralPage = () => {
                   onClick={onInsertYAML}
                   variant="secondary"
                 >
-                  Insert {context.kind.toLowerCase()} YAML at cursor
+                  Insert {context.kind} YAML at cursor
                 </Button>
               </Alert>
             </>


### PR DESCRIPTION
Enable for CronJob, DaemonSet, ReplicaSet and StatefulSet These all use the standard details page component in the web console, so we can reuse the existing `K8sResourceActionsProvider` code.