### PR TITLE
Increase OLS API timeout to 10 minutes

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -33,7 +33,7 @@ import { State } from '../redux-reducers';
 import './general-page.css';
 
 const QUERY_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/query';
-const QUERY_TIMEOUT = 60 * 1000;
+const QUERY_TIMEOUT = 10 * 60 * 1000; // 10 minutes
 
 type QueryResponse = {
   conversation_id: string;


### PR DESCRIPTION
We don't want the frontend timing out before the backend, so set the timeout pretty high.