### PR TITLE
Remove separate OLS page from web console

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -70,24 +70,6 @@
     }
   },
   {
-    "type": "console.page/route",
-    "properties": {
-      "exact": true,
-      "path": "/lightspeed",
-      "component": { "$codeRef": "GeneralPage" }
-    }
-  },
-  {
-    "type": "console.navigation/href",
-    "properties": {
-      "id": "LightspeedGeneral",
-      "name": "%plugin__lightspeed-console-plugin~OpenShift Lightspeed%",
-      "href": "/lightspeed",
-      "perspective": "admin",
-      "section": "home"
-    }
-  },
-  {
     "type": "console.redux-reducer",
     "properties": {
       "scope": "ols",

--- a/locales/en/plugin__lightspeed-console-plugin.json
+++ b/locales/en/plugin__lightspeed-console-plugin.json
@@ -3,7 +3,6 @@
   "Error getting YAML: {{e}}": "Error getting YAML: {{e}}",
   "Hello there. How can I help?": "Hello there. How can I help?",
   "New chat": "New chat",
-  "OpenShift Lightspeed": "OpenShift Lightspeed",
   "Red Hat OpenShift Lightspeed": "Red Hat OpenShift Lightspeed",
   "Send a message...": "Send a message..."
 }

--- a/package.json
+++ b/package.json
@@ -78,9 +78,8 @@
     "description": "Add UI elements for interacting with OpenShift Lightspeed to the OpenShift web console.",
     "exposedModules": {
       "AlertActionsProvider": "./hooks/useAlertExtension",
-      "NullContextProvider": "./components/NullContextProvider",
-      "GeneralPage": "./components/GeneralPage",
       "K8sResourceActionsProvider": "./hooks/useK8sResourceExtension",
+      "NullContextProvider": "./components/NullContextProvider",
       "OLSReducer": "./redux-reducers",
       "OverviewDetail": "./components/OverviewDetail",
       "usePopover": "./hooks/usePopover"

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -1,7 +1,6 @@
 import { dump } from 'js-yaml';
 import { defer } from 'lodash';
 import * as React from 'react';
-import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -251,9 +250,6 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
 
   return (
     <>
-      <Helmet>
-        <title>{t('OpenShift Lightspeed')}</title>
-      </Helmet>
       <Page>
         <PageSection className="ols-plugin__page-title" variant="light">
           {onClose && <TimesIcon className="ols-plugin__popover-close" onClick={onClose} />}


### PR DESCRIPTION
With this change, OLS is only accessible using the popover UI.