### PR TITLE
OLS-442: Move prompt text to Redux so it isn't lost when the popover is closed

### DIFF
--- a/src/redux-actions.ts
+++ b/src/redux-actions.ts
@@ -6,6 +6,7 @@ export enum ActionType {
   OpenOLS = 'openOLS',
   SetChatHistory = 'setChatHistory',
   SetContext = 'setContext',
+  SetQuery = 'setQuery',
 }
 
 export const closeOLS = () => action(ActionType.CloseOLS);
@@ -14,7 +15,8 @@ export const openOLS = () => action(ActionType.OpenOLS);
 export const setChatHistory = (chatHistory: object) =>
   action(ActionType.SetChatHistory, { chatHistory });
 export const setContext = (context: object) => action(ActionType.SetContext, { context });
+export const setQuery = (query: string) => action(ActionType.SetQuery, { query });
 
-const actions = { closeOLS, dismissPrivacyAlert, openOLS, setChatHistory, setContext };
+const actions = { closeOLS, dismissPrivacyAlert, openOLS, setChatHistory, setContext, setQuery };
 
 export type OLSAction = Action<typeof actions>;

--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -17,6 +17,7 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
       context: null,
       isOpen: false,
       isPrivacyAlertDismissed: false,
+      query: '',
     });
   }
 
@@ -32,6 +33,9 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
 
     case ActionType.SetContext:
       return state.set('context', action.payload.context);
+
+    case ActionType.SetQuery:
+      return state.set('query', action.payload.query);
 
     case ActionType.SetChatHistory:
       return state.set('chatHistory', action.payload.chatHistory);


### PR DESCRIPTION
Store the current prompt text in Redux instead of component state so that it is persisted when the popover is closed and reopened.

Also drop the default prompt text when chatting about a k8s resource.