### PR TITLE
OLS-462: Implement separate user feedback for each response and move to redux

### DIFF
--- a/src/redux-actions.ts
+++ b/src/redux-actions.ts
@@ -1,22 +1,49 @@
 import { action, ActionType as Action } from 'typesafe-actions';
 
+import { ChatEntry } from './types';
+
 export enum ActionType {
+  ChatHistoryClear = 'chatHistoryClear',
+  ChatHistoryPush = 'chatHistoryPush',
   CloseOLS = 'closeOLS',
   DismissPrivacyAlert = 'dismissPrivacyAlert',
   OpenOLS = 'openOLS',
-  SetChatHistory = 'setChatHistory',
   SetContext = 'setContext',
   SetQuery = 'setQuery',
+  UserFeedbackClose = 'userFeedbackClose',
+  UserFeedbackOpen = 'userFeedbackOpen',
+  UserFeedbackSetSentiment = 'userFeedbackSetSentiment',
+  UserFeedbackSetText = 'userFeedbackSetText',
 }
 
+export const chatHistoryClear = () => action(ActionType.ChatHistoryClear);
+export const chatHistoryPush = (entry: ChatEntry) => action(ActionType.ChatHistoryPush, { entry });
 export const closeOLS = () => action(ActionType.CloseOLS);
 export const dismissPrivacyAlert = () => action(ActionType.DismissPrivacyAlert);
 export const openOLS = () => action(ActionType.OpenOLS);
-export const setChatHistory = (chatHistory: object) =>
-  action(ActionType.SetChatHistory, { chatHistory });
 export const setContext = (context: object) => action(ActionType.SetContext, { context });
 export const setQuery = (query: string) => action(ActionType.SetQuery, { query });
+export const userFeedbackClose = (entryIndex: number) =>
+  action(ActionType.UserFeedbackClose, { entryIndex });
+export const userFeedbackOpen = (entryIndex: number) =>
+  action(ActionType.UserFeedbackOpen, { entryIndex });
+export const userFeedbackSetSentiment = (entryIndex: number, sentiment: number) =>
+  action(ActionType.UserFeedbackSetSentiment, { entryIndex, sentiment });
+export const userFeedbackSetText = (entryIndex: number, text: string) =>
+  action(ActionType.UserFeedbackSetText, { entryIndex, text });
 
-const actions = { closeOLS, dismissPrivacyAlert, openOLS, setChatHistory, setContext, setQuery };
+const actions = {
+  chatHistoryClear,
+  chatHistoryPush,
+  closeOLS,
+  dismissPrivacyAlert,
+  openOLS,
+  setContext,
+  setQuery,
+  userFeedbackClose,
+  userFeedbackOpen,
+  userFeedbackSetSentiment,
+  userFeedbackSetText,
+};
 
 export type OLSAction = Action<typeof actions>;

--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -1,8 +1,9 @@
-import { Map as ImmutableMap } from 'immutable';
+import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import { ActionType, OLSAction } from './redux-actions';
 
-export type OLSState = ImmutableMap<string, unknown>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OLSState = ImmutableMap<string, any>;
 
 export type State = {
   plugins: {
@@ -13,7 +14,7 @@ export type State = {
 const reducer = (state: OLSState, action: OLSAction): OLSState => {
   if (!state) {
     return ImmutableMap({
-      chatHistory: [],
+      chatHistory: ImmutableList(),
       context: null,
       isOpen: false,
       isPrivacyAlertDismissed: false,
@@ -22,6 +23,15 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
   }
 
   switch (action.type) {
+    case ActionType.ChatHistoryClear:
+      return state.set('chatHistory', ImmutableList());
+
+    case ActionType.ChatHistoryPush:
+      return state.set(
+        'chatHistory',
+        state.get('chatHistory').push(ImmutableMap(action.payload.entry)),
+      );
+
     case ActionType.CloseOLS:
       return state.set('isOpen', false);
 
@@ -37,8 +47,29 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
     case ActionType.SetQuery:
       return state.set('query', action.payload.query);
 
-    case ActionType.SetChatHistory:
-      return state.set('chatHistory', action.payload.chatHistory);
+    case ActionType.UserFeedbackClose:
+      return state.setIn(
+        ['chatHistory', action.payload.entryIndex, 'userFeedback', 'isOpen'],
+        false,
+      );
+
+    case ActionType.UserFeedbackOpen:
+      return state.setIn(
+        ['chatHistory', action.payload.entryIndex, 'userFeedback', 'isOpen'],
+        true,
+      );
+
+    case ActionType.UserFeedbackSetSentiment:
+      return state.setIn(
+        ['chatHistory', action.payload.entryIndex, 'userFeedback', 'sentiment'],
+        action.payload.sentiment,
+      );
+
+    case ActionType.UserFeedbackSetText:
+      return state.setIn(
+        ['chatHistory', action.payload.entryIndex, 'userFeedback', 'text'],
+        action.payload.text,
+      );
 
     default:
       break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+import { Map as ImmutableMap } from 'immutable';
+
+type ChatEntryUser = {
+  text: string;
+  who: 'user';
+};
+
+type ChatEntryAI = {
+  error?: string;
+  references?: Array<string>;
+  text: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userFeedback?: ImmutableMap<string, any>;
+  who: 'ai';
+};
+
+export type ChatEntry = ChatEntryAI | ChatEntryUser;


### PR DESCRIPTION
Store the user feedback in redux as part of the chat history so that we can store different user feedback for each response and persist it when the user feedback area is closed and when the whole OLS popover UI is closed.

Also converts the chat history in Redux from a standard Array to an Immutable List so that we can use the Immutable.js getIn function to extract specific fields from within the nested data.