### PR TITLE
Fix "New chat" button margin

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -709,10 +709,12 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
           {!isWelcomePage && (
             <Level>
               <LevelItem>
-                <Title headingLevel="h1">{t('Red Hat OpenShift Lightspeed')}</Title>
+                <Title className="ols-plugin__heading" headingLevel="h1">
+                  {t('Red Hat OpenShift Lightspeed')}
+                </Title>
               </LevelItem>
               <LevelItem>
-                <Button className="ols-plugin__new-chat" onClick={clearChat} variant="primary">
+                <Button onClick={clearChat} variant="primary">
                   {t('New chat')}
                 </Button>
               </LevelItem>

--- a/src/components/general-page.css
+++ b/src/components/general-page.css
@@ -144,8 +144,8 @@
   padding-left: calc(var(--logo-spacer-left) + var(--logo-size) + var(--logo-spacer-right));
 }
 
-.ols-plugin__new-chat {
-  margin-left: var(--pf-v5-global--spacer--md);
+.ols-plugin__heading {
+  margin-right: var(--pf-v5-global--spacer--md);
 }
 
 .ols-plugin__references {


### PR DESCRIPTION
Fix margins so that the "New chat" button is left aligned with the heading if it can't fit to the right of the heading.