### PR TITLE
Add React error boundary to contain any thrown errors to the plugin

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { isError: boolean }> {
+  constructor(props) {
+    super(props);
+    this.state = { isError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    console.error(`Caught OpenShift Lightspeed plugin error:
+Message: "${error?.message}"
+Stack:
+${error?.stack}`);
+
+    return { isError: true };
+  }
+
+  render() {
+    return this.state.isError ? null : this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { useBoolean } from '../hooks/useBoolean';
 import { closeOLS, openOLS } from '../redux-actions';
 import { State } from '../redux-reducers';
+import ErrorBoundary from './ErrorBoundary';
 import GeneralPage from './GeneralPage';
 
 import './popover.css';
@@ -53,4 +54,10 @@ const Popover: React.FC = () => {
   );
 };
 
-export default Popover;
+const PopoverWithErrorBoundary: React.FC = () => (
+  <ErrorBoundary>
+    <Popover />
+  </ErrorBoundary>
+);
+
+export default PopoverWithErrorBoundary;


### PR DESCRIPTION
Currently doesn't display a user visible error message, but logs the error details in the browser console since this is mostly for debugging.