### PR TITLE
OLS-534,OLS-555: Add attachments to chat history and add attachment details popover

### DIFF
--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,11 +1,16 @@
-import { Attachment, Attachments } from './types';
+import { Map as ImmutableMap } from 'immutable';
+
+import { Attachment } from './types';
 
 export enum AttachmentTypes {
   YAML = 'YAML',
   YAMLStatus = 'YAML Status',
 }
 
-export const buildQuery = (query: string, attachments: Attachments): string => {
+export const buildQuery = (
+  query: string,
+  attachments: ImmutableMap<string, Attachment>,
+): string => {
   let fullQuery = query;
 
   attachments.forEach((attachment: Attachment) => {

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -1,3 +1,4 @@
+import { Map as ImmutableMap } from 'immutable';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -31,7 +32,7 @@ import {
   userFeedbackSetText,
 } from '../redux-actions';
 import { State } from '../redux-reducers';
-import { Attachments } from '../types';
+import { Attachment } from '../types';
 import ErrorBoundary from './ErrorBoundary';
 
 const USER_FEEDBACK_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/feedback';
@@ -58,7 +59,7 @@ const Feedback: React.FC<FeedbackProps> = ({ conversationID, entryIndex, scrollI
   const query: string = useSelector((s: State) =>
     s.plugins?.ols?.getIn(['chatHistory', entryIndex - 1, 'text']),
   );
-  const queryAttachments: Attachments = useSelector((s: State) =>
+  const queryAttachments: ImmutableMap<string, Attachment> = useSelector((s: State) =>
     s.plugins?.ols?.getIn(['chatHistory', entryIndex - 1, 'attachments']),
   );
   const response: string = useSelector((s: State) =>

--- a/src/components/general-page.css
+++ b/src/components/general-page.css
@@ -6,13 +6,6 @@
   margin-bottom: var(--pf-v5-global--spacer--lg);
 }
 
-.ols-plugin__chat-history {
-  overflow-y: auto;
-  padding-bottom: 0;
-  padding-left: 8%;
-  padding-right: 8%;
-}
-
 .ols-plugin__chat-entry {
   --logo-size: 2.5rem;
 
@@ -37,6 +30,30 @@
 
 .ols-plugin__chat-entry-text {
   white-space: pre-line;
+}
+
+.ols-plugin__chat-history {
+  overflow-y: auto;
+  padding-bottom: 0;
+  padding-left: 8%;
+  padding-right: 8%;
+}
+
+.ols-plugin__chat-history-context {
+  background-color: var(--pf-v5-global--BackgroundColor--200);
+  box-shadow: 3px 0 0 0 var(--pf-v5-global--primary-color--100) inset;
+  margin-top: var(--pf-global--spacer--md);
+  padding: var(--pf-global--spacer--sm);
+}
+
+.ols-plugin__chat-history-context-count {
+  margin-left: var(--pf-global--spacer--sm);
+}
+
+.ols-plugin__context-code-block-code {
+  font-size: 12px;
+  max-height: 10rem;
+  overflow: auto;
 }
 
 .ols-plugin__feedback {
@@ -111,9 +128,14 @@
 }
 
 .ols-plugin__context-label {
+  cursor: pointer;
   font-weight: var(--pf-v5-global--FontWeight--bold);
   margin-right: var(--pf-v5-global--spacer--sm);
   margin-top: var(--pf-v5-global--spacer--sm);
+}
+
+.ols-plugin__context-label-type {
+  margin-left: var(--pf-global--spacer--sm);
 }
 
 .ols-plugin__context-menu {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,10 +5,8 @@ export type Attachment = {
   kind: string;
   name: string;
   namespace: string;
-  value: object;
+  value: string;
 };
-
-export type Attachments = ImmutableMap<string, Attachment>;
 
 export type ReferencedDoc = {
   docs_url: string;
@@ -16,7 +14,7 @@ export type ReferencedDoc = {
 };
 
 type ChatEntryUser = {
-  attachments: Attachments;
+  attachments: { [key: string]: Attachment };
   text: string;
   who: 'user';
 };


### PR DESCRIPTION
In the chat history, show any attachments that were added to each prompt.

Also add a popover to the attachment labels (used both below the current prompt input and in the chat history). The popover shows the resource kind, name and namespace as well as the YAML that is actually attached to the prompt.