### PR TITLE
Improve attachment label truncation

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -155,8 +155,9 @@ const AttachmentLabel: React.FC<AttachmentLabelProps> = ({ attachment, onClose }
       position="left"
       triggerAction="hover"
     >
-      <Label className="ols-plugin__context-label" onClose={onClose} textMaxWidth="16rem">
-        <ResourceIcon kind={attachment.kind} /> {attachment.name}
+      <Label className="ols-plugin__context-label" onClose={onClose}>
+        <ResourceIcon kind={attachment.kind} />
+        <span className="ols-plugin__context-label-text">{attachment.name}</span>{' '}
         <Label className="ols-plugin__context-label-type">{attachment.attachmentType}</Label>
       </Label>
     </Popover>

--- a/src/components/general-page.css
+++ b/src/components/general-page.css
@@ -137,8 +137,15 @@
   margin-top: var(--pf-v5-global--spacer--sm);
 }
 
+.ols-plugin__context-label-text {
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .ols-plugin__context-label-type {
-  margin-left: var(--pf-global--spacer--sm);
+  margin-left: var(--pf-global--spacer--xs);
 }
 
 .ols-plugin__context-menu {


### PR DESCRIPTION
Improve truncation of the attachment labels so that the attachment type (currently YAML or Status YAML) is always visible.