### PR TITLE
Change popover close icon from TimesIcon to WindowMinimizeIcon

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -48,7 +48,7 @@ import {
   FileCodeIcon,
   PaperPlaneIcon,
   PlusCircleIcon,
-  TimesIcon,
+  WindowMinimizeIcon,
 } from '@patternfly/react-icons';
 
 import { AttachmentTypes, buildQuery } from '../attachments';
@@ -587,11 +587,11 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
     <>
       <Page>
         <PageSection className={isWelcomePage ? undefined : 'ols-plugin__header'} variant="light">
-          <TimesIcon className="ols-plugin__popover-close" onClick={onClose} />
           {onExpand && <ExpandIcon className="ols-plugin__popover-close" onClick={onExpand} />}
           {onCollapse && (
             <CompressIcon className="ols-plugin__popover-close" onClick={onCollapse} />
           )}
+          <WindowMinimizeIcon className="ols-plugin__popover-close" onClick={onClose} />
           {!isWelcomePage && (
             <Level>
               <LevelItem>


### PR DESCRIPTION
Conceptually, this button's action is closer to minimizing the window than to closing the window. Especially since the chat history any currently entered text will be preserved.