### PR TITLE
OLS-531: Use looser phrasing for describing RAG references

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -200,7 +200,7 @@ const ChatHistoryEntry: React.FC<ChatHistoryEntryProps> = ({
               </Alert>
             )}
             {entry.references && (
-              <ChipGroup categoryName="Referenced docs" className="ols-plugin__references">
+              <ChipGroup categoryName="Related documentation" className="ols-plugin__references">
                 {entry.references.map((r, i) => (
                   <DocLink reference={r} key={i} />
                 ))}


### PR DESCRIPTION
see discussion in https://issues.redhat.com/browse/OLS-531 for what motivated the change.

tldr: the LLM didn't actually have access to the entire doc to generate the response (only some section of that linked doc), and it may not have used any of the content. So listing the docs are "related" rather than "referenced" avoids creating a false impression