### PR TITLE
Remove "YAML" label for alert attachments

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -202,7 +202,9 @@ const AttachmentLabel: React.FC<AttachmentLabelProps> = ({ attachment, onClose }
       <Label className="ols-plugin__context-label" onClose={onClose}>
         <ResourceIcon kind={kind} />
         <span className="ols-plugin__context-label-text">{name}</span>{' '}
-        <Label className="ols-plugin__context-label-type">{attachmentType}</Label>
+        {kind !== 'Alert' && (
+          <Label className="ols-plugin__context-label-type">{attachmentType}</Label>
+        )}
       </Label>
     </Popover>
   );


### PR DESCRIPTION
The alert attachments can only be YAML attachments, so we don't add a label in this case.