### PR TITLE
OLS-690: Limit the height of code blocks in OLS responses

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -153,8 +153,8 @@ const Code = ({ children }: { children: React.ReactNode }) => {
   );
 
   return (
-    <CodeBlock actions={actions} className="ols-plugin__code-block">
-      {children}
+    <CodeBlock actions={actions}>
+      <CodeBlockCode className="ols-plugin__code-block">{children}</CodeBlockCode>
     </CodeBlock>
   );
 };

--- a/src/components/general-page.css
+++ b/src/components/general-page.css
@@ -51,7 +51,9 @@
 }
 
 .ols-plugin__code-block {
-  overflow: auto;
+  max-height: 8rem;
+  overflow: scroll;
+  white-space: pre;
 }
 
 .ols-plugin__context-code-block-code {


### PR DESCRIPTION
Code blocks can be scrolled if they don't fit in the max-height.