### PR TITLE
Set webpack version override for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   },
+  "overrides": {
+    "webpack": "5.91.0"
+  },
   "resolutions": {
     "webpack": "5.91.0"
   },


### PR DESCRIPTION
Webpack version must match the version used by the plugin SDK