### PR TITLE
OLS-717: Pass attachments in separate fields to OLS

### DIFF
--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,5 +1,3 @@
-import { Map as ImmutableMap } from 'immutable';
-
 import { Attachment } from './types';
 
 export enum AttachmentTypes {
@@ -9,51 +7,19 @@ export enum AttachmentTypes {
   YAMLStatus = 'YAML Status',
 }
 
-export const buildQuery = (
-  query: string,
-  attachments: ImmutableMap<string, Attachment>,
-): string => {
-  let fullQuery = query;
+export const toOLSAttachment = (attachment: Attachment) => {
+  let attachment_type = 'api object';
+  if (attachment.attachmentType === AttachmentTypes.Events) {
+    attachment_type = 'event';
+  }
+  if (attachment.attachmentType === AttachmentTypes.Log) {
+    attachment_type = 'log';
+  }
 
-  attachments.forEach((attachment: Attachment) => {
-    const { attachmentType, kind, name, options, value } = attachment;
-
-    if (attachmentType === AttachmentTypes.YAML) {
-      fullQuery += `
-
-For reference, here is the full resource YAML for ${kind} '${name}':
-\`\`\`yaml
-${value}
-\`\`\``;
-    }
-
-    if (attachmentType === AttachmentTypes.YAMLStatus) {
-      fullQuery += `
-
-For reference, here is the resource's 'status' section YAML for ${kind} '${name}':
-\`\`\`yaml
-${value}
-\`\`\``;
-    }
-
-    if (attachmentType === AttachmentTypes.Events) {
-      fullQuery += `
-
-For reference, here are the most recent ${options?.lines} events for ${kind} '${name}':
-\`\`\`
-${value}
-\`\`\``;
-    }
-
-    if (attachmentType === AttachmentTypes.Log) {
-      fullQuery += `
-
-For reference, here are the most recent ${options?.lines} lines from the log for ${kind} '${name}':
-\`\`\`
-${value}
-\`\`\``;
-    }
-  });
-
-  return fullQuery;
+  return {
+    attachment_type,
+    content: attachment.value,
+    content_type:
+      attachment.attachmentType === AttachmentTypes.Log ? 'text/plain' : 'application/yaml',
+  };
 };

--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -88,12 +88,7 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
       e.preventDefault();
 
       const yaml = dump(events.slice(-numEvents), { lineWidth: -1 }).trim();
-      dispatch(
-        attachmentAdd(AttachmentTypes.Events, kind, name, namespace, yaml, {
-          owner: name,
-          lines: numEvents,
-        }),
-      );
+      dispatch(attachmentAdd(AttachmentTypes.Events, kind, name, namespace, yaml));
       onClose();
     },
     [dispatch, events, kind, name, namespace, numEvents, onClose],

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -121,8 +121,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({
               'Container',
               container,
               namespace,
-              response?.trim(),
-              { lines, owner: pod },
+              `Most recent lines from the log for Container '${container}', belonging to pod '${pod}':\n\n${response?.trim()}`,
             ),
           );
           onClose();

--- a/src/redux-actions.ts
+++ b/src/redux-actions.ts
@@ -1,6 +1,6 @@
 import { action, ActionType as Action } from 'typesafe-actions';
 
-import { Attachment, AttachmentOptions, ChatEntry } from './types';
+import { Attachment, ChatEntry } from './types';
 
 export enum ActionType {
   AttachmentAdd = 'attachmentAdd',
@@ -27,7 +27,6 @@ export const attachmentAdd = (
   name: string,
   namespace: string,
   value: string,
-  options: AttachmentOptions = null,
 ) =>
   action(ActionType.AttachmentAdd, {
     attachmentType,
@@ -35,7 +34,6 @@ export const attachmentAdd = (
     name,
     namespace,
     value,
-    options,
   });
 export const attachmentDelete = (id: string) => action(ActionType.AttachmentDelete, { id });
 export const attachmentsClear = () => action(ActionType.AttachmentsClear);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,10 @@
 import { Map as ImmutableMap } from 'immutable';
 
-export type AttachmentOptions = {
-  lines: number;
-  owner: string;
-};
-
 export type Attachment = {
   attachmentType: string;
   kind: string;
   name: string;
   namespace: string;
-  options: AttachmentOptions;
   value: string;
 };
 


### PR DESCRIPTION
So that OLS has enough context to know what each attachment belongs to, we now also include the resource's `kind` and `metadata` with the `status` YAML attachment.

Similarly, we previx log attachments with a line of text explaning which container and pod it belongs to.

Also removes the attachment's `options` data from redux since it is no longer used.