### PR TITLE
Downgrade plugin SDK packages to OpenShift 4.15 compatible versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openshift-console/dynamic-plugin-sdk": "1.3.0",
-        "@openshift-console/dynamic-plugin-sdk-webpack": "1.1.0",
+        "@openshift-console/dynamic-plugin-sdk": "1.0.0",
+        "@openshift-console/dynamic-plugin-sdk-webpack": "1.0.2",
         "@patternfly/react-core": "5.3.3",
         "@patternfly/react-icons": "5.3.2",
         "@types/node": "^20.14.7",
@@ -2928,9 +2928,9 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.3.0.tgz",
-      "integrity": "sha512-TTclIiLrgV+d/GLXmMBpRf6lt9qQ2a9Ur53RtRYp0HGDT4fystMto/xEwSM5b2B17rL03LxATvmK96GIk1BWXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0.tgz",
+      "integrity": "sha512-Rgj3LuOPJGW1W/KP9luIvZMFHyb8qFTrH2RB2xJ9r4NY2enDLS8eaN79AejV9fNO7v025Fh6MKtTjMnYOoyZVg==",
       "dependencies": {
         "classnames": "2.x",
         "immutable": "3.x",
@@ -2949,9 +2949,9 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk-webpack": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.1.0.tgz",
-      "integrity": "sha512-UukGhZOEGc5u22hoO3H0bP58r+Kw1gDFBe0EEJTkYkzYX6S0og5DNAVw/lzhwUorpbmy00B6cqWIuclmTo1+QA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.2.tgz",
+      "integrity": "sha512-6Byj94mVqSd+gzdVnOxyYFAUfwIlY7ONDBVWToK9B4zJYXvpR9Zdq9ZZIZ27tb+IbfOZ4lNNVo056C0tE0FGcQ==",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.2",
         "ajv": "^6.12.3",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "cypress-postreport": "yarn cypress-merge && yarn cypress-generate"
   },
   "dependencies": {
-    "@openshift-console/dynamic-plugin-sdk": "1.3.0",
-    "@openshift-console/dynamic-plugin-sdk-webpack": "1.1.0",
+    "@openshift-console/dynamic-plugin-sdk": "1.0.0",
+    "@openshift-console/dynamic-plugin-sdk-webpack": "1.0.2",
     "@patternfly/react-core": "5.3.3",
     "@patternfly/react-icons": "5.3.2",
     "@types/node": "^20.14.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,10 +378,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openshift-console/dynamic-plugin-sdk-webpack@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.1.0.tgz#d369c37b93cd0792960385728de5cd1f63c2187f"
-  integrity sha512-UukGhZOEGc5u22hoO3H0bP58r+Kw1gDFBe0EEJTkYkzYX6S0og5DNAVw/lzhwUorpbmy00B6cqWIuclmTo1+QA==
+"@openshift-console/dynamic-plugin-sdk-webpack@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.2.tgz#0e5ed38307cc5b4ce23c55a3bfafa0c3dea54803"
+  integrity sha512-6Byj94mVqSd+gzdVnOxyYFAUfwIlY7ONDBVWToK9B4zJYXvpR9Zdq9ZZIZ27tb+IbfOZ4lNNVo056C0tE0FGcQ==
   dependencies:
     "@openshift/dynamic-plugin-sdk-webpack" "^4.0.2"
     ajv "^6.12.3"
@@ -394,10 +394,10 @@
     semver "6.x"
     webpack "5.75.0"
 
-"@openshift-console/dynamic-plugin-sdk@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.3.0.tgz#70d48743e56c5f8887b173087a5804411b5c9510"
-  integrity sha512-TTclIiLrgV+d/GLXmMBpRf6lt9qQ2a9Ur53RtRYp0HGDT4fystMto/xEwSM5b2B17rL03LxATvmK96GIk1BWXQ==
+"@openshift-console/dynamic-plugin-sdk@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0.tgz#af281184805b79e6891145fd1d915e01e869b295"
+  integrity sha512-Rgj3LuOPJGW1W/KP9luIvZMFHyb8qFTrH2RB2xJ9r4NY2enDLS8eaN79AejV9fNO7v025Fh6MKtTjMnYOoyZVg==
   dependencies:
     classnames "2.x"
     immutable "3.x"


### PR DESCRIPTION
These are the latest versions that have backwards compatibility with version 4.15.x 