### PR TITLE
OLS-872: Remove tooltip from Sliders and add current count to labels instead

### DIFF
--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -101,7 +101,7 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
         )}
       </Text>
       <Form>
-        <FormGroup isRequired label={t('Number of events (most recent)')}>
+        <FormGroup isRequired label={t('Most recent {{numEvents}} events', { numEvents })}>
           {isLoading && <Spinner size="md" />}
           {!isLoading &&
             (events.length === 0 ? (
@@ -110,7 +110,6 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
               </HelperText>
             ) : (
               <Slider
-                hasTooltipOverThumb
                 max={events.length}
                 min={1}
                 onChange={onInputNumEventsChange}

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -178,8 +178,8 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({
         <FormGroup isRequired label="Container">
           <ContainerInput containers={containers} setValue={setContainer} value={container} />
         </FormGroup>
-        <FormGroup isRequired label={t('Number of lines (most recent)')}>
-          <Slider hasTooltipOverThumb max={100} min={1} onChange={onLinesChange} value={lines} />
+        <FormGroup isRequired label={t('Most recent {{lines}} lines', { lines })}>
+          <Slider max={100} min={1} onChange={onLinesChange} value={lines} />
         </FormGroup>
         <ActionGroup>
           <Button onClick={onSubmit} type="submit" variant="primary">


### PR DESCRIPTION
For the attach logs modal and the attach events modal, remove the tooltip above the Slider component. Instead show the currently selected count in the input label. This solves a problem where the tooltip would jitter as the slider was dragged. It also means the the count is always visible without having to hover over the slider.