### PR TITLE
OLS-860: Fix display of OLS API error messages

### DIFF
--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -24,6 +24,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { toOLSAttachment } from '../attachments';
+import { ErrorType, getFetchErrorMessage } from '../error';
 import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import {
   userFeedbackClose,
@@ -72,7 +73,7 @@ const Feedback: React.FC<Props> = ({ conversationID, entryIndex, scrollIntoView 
     s.plugins?.ols?.getIn(['chatHistory', entryIndex, 'userFeedback', 'text']),
   );
 
-  const [error, setError] = React.useState<string>();
+  const [error, setError] = React.useState<ErrorType>();
   const [submitted, setSubmitted] = React.useState(false);
 
   const onClose = React.useCallback(() => {
@@ -122,10 +123,10 @@ const Feedback: React.FC<Props> = ({ conversationID, entryIndex, scrollIntoView 
         setSubmitted(true);
       })
       .catch((err) => {
-        setError(err.json?.detail || err.message || 'Feedback POST failed');
+        setError(getFetchErrorMessage(err, t));
         setSubmitted(false);
       });
-  }, [conversationID, dispatch, entryIndex, query, attachments, response, sentiment, text]);
+  }, [conversationID, dispatch, entryIndex, query, attachments, response, sentiment, t, text]);
 
   return (
     <>
@@ -175,11 +176,12 @@ const Feedback: React.FC<Props> = ({ conversationID, entryIndex, scrollIntoView 
             {error && (
               <Alert
                 className="ols-plugin__alert"
+                isExpandable={!!error.moreInfo}
                 isInline
-                title={t('Error submitting feedback')}
+                title={error.moreInfo ? error.message : t('Error submitting feedback')}
                 variant="danger"
               >
-                {error}
+                {error.moreInfo ? error.moreInfo : error.message}
               </Alert>
             )}
             <Button onClick={onSubmit} variant="primary">

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,24 @@
+import { TFunction } from 'react-i18next';
+
+export type ErrorType = {
+  message: string;
+  moreInfo?: string;
+};
+
+// Extracts the error message from a Fetch error
+export const getFetchErrorMessage = (error, t: TFunction): ErrorType => {
+  // For OpenShift Lightspeed API errors, the `detail` field will either be a single string or
+  // an object containing `response` and `cause` strings
+  const detail = error.json?.detail;
+  if (detail && typeof detail === 'string') {
+    return { message: detail };
+  }
+  if (detail && typeof detail.response === 'string' && typeof detail.cause === 'string') {
+    return { message: detail.response, moreInfo: detail.cause };
+  }
+  return {
+    message: t('If this error persists, please contact an administrator. Error details: {{e}}', {
+      e: error.json?.message || error.message || error.response?.statusText,
+    }),
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import { Map as ImmutableMap } from 'immutable';
 
+import { ErrorType } from './error';
+
 export type Attachment = {
   attachmentType: string;
   kind: string;
@@ -21,7 +23,7 @@ type ChatEntryUser = {
 };
 
 type ChatEntryAI = {
-  error?: string;
+  error?: ErrorType;
   isTruncated: boolean;
   references?: Array<ReferencedDoc>;
   text?: string;


### PR DESCRIPTION
Use the same logic for the `query` and `feedback` endpoints to catch all the possible errors for both endpoints.