### PR TITLE
Revert nudge configs

### DIFF
--- a/.tekton/lightspeed-console-push.yaml
+++ b/.tekton/lightspeed-console-push.yaml
@@ -7,8 +7,6 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
-    build.appstudio.openshift.io/build-nudge-files: |
-      .*Dockerfile.*, ^(?!lightspeed-catalog.*\/).*\.yaml$, .*Containerfile.*
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols


### PR DESCRIPTION
This reverts commit 1b57dc04e38f47e4d350dc1ad432e59b73138a55.

The new nudge configs does not work as expected. We revert this change while figuring out the correct nudge settings.