### PR TITLE
OLS-989: Fix to hide Edit button for attachments in chat history

### DIFF
--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -176,9 +176,11 @@ const AttachmentModal: React.FC = () => {
         ) : (
           <Split>
             <SplitItem isFilled>
-              <Button onClick={setEditing} type="submit" variant="primary">
-                {t('Edit')}
-              </Button>
+              {attachment?.isEditable && (
+                <Button onClick={setEditing} type="submit" variant="primary">
+                  {t('Edit')}
+                </Button>
+              )}
               <Button onClick={onClose} variant="link">
                 {t('Dismiss')}
               </Button>

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -142,17 +142,18 @@ const Code = ({ children }: { children: React.ReactNode }) => {
 
 type AttachmentLabelProps = {
   attachment: Attachment;
+  isEditable?: boolean;
   onClose?: () => void;
 };
 
-const AttachmentLabel: React.FC<AttachmentLabelProps> = ({ attachment, onClose }) => {
+const AttachmentLabel: React.FC<AttachmentLabelProps> = ({ attachment, isEditable, onClose }) => {
   const { t } = useTranslation('plugin__lightspeed-console-plugin');
 
   const dispatch = useDispatch();
 
   const onClick = React.useCallback(() => {
-    dispatch(openAttachmentSet(attachment));
-  }, [attachment, dispatch]);
+    dispatch(openAttachmentSet(Object.assign({}, attachment, { isEditable })));
+  }, [attachment, isEditable, dispatch]);
 
   if (!attachment) {
     return null;
@@ -811,6 +812,7 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
                     return (
                       <AttachmentLabel
                         attachment={attachment}
+                        isEditable
                         key={id}
                         onClose={() => dispatch(attachmentDelete(id))}
                       />

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import { ErrorType } from './error';
 
 export type Attachment = {
   attachmentType: string;
+  isEditable?: boolean;
   kind: string;
   name: string;
   namespace: string;


### PR DESCRIPTION
The attachment modal should only allow editing the attachment if it is being viewed before submitting the prompt. When opened from the chat history, the Edit button should not be shown.