### PR TITLE
OLS-997: Fix attachment save with wrong value after revert

### DIFF
--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -134,7 +134,8 @@ const AttachmentModal: React.FC = () => {
   }, [attachment, dispatch, editorValue, setNotEditing]);
 
   const onRevert = React.useCallback(() => {
-    dispatch(openAttachmentSet(Object.assign({}, attachment, { value: attachment.originalValue })));
+    const value = attachment.originalValue;
+    dispatch(openAttachmentSet(Object.assign({}, attachment, { value })));
     dispatch(
       attachmentSet(
         attachment.attachmentType,
@@ -142,10 +143,11 @@ const AttachmentModal: React.FC = () => {
         attachment.name,
         attachment.ownerName,
         attachment.namespace,
-        attachment.originalValue,
+        value,
         undefined,
       ),
     );
+    setEditorValue(value);
   }, [attachment, dispatch]);
 
   return (


### PR DESCRIPTION
Fixes a bug where the value of the attachment editor text was not updated after clicking the "Revert to original" button. This meant that the editor would save with the wrong value when following these steps:
1. Add any attachment to the prompt
2. Edit the attachment
3. Revert your edit
4. Edit the attachment again, but hit "Save" without actually changing the text
5. The attachment will have saved with the value from step (2)