### PR TITLE
OLS-1000: Fix attach events and attach logs modals to call onClose on unmount

### DIFF
--- a/locales/en/plugin__lightspeed-console-plugin.json
+++ b/locales/en/plugin__lightspeed-console-plugin.json
@@ -31,6 +31,7 @@
   "Failed to attach context": "Failed to attach context",
   "Failed to fetch logs": "Failed to fetch logs",
   "Failed to find definition YAML for alert": "Failed to find definition YAML for alert",
+  "Failed to load events": "Failed to load events",
   "Failed to load pods": "Failed to load pods",
   "Good response": "Good response",
   "History truncated": "History truncated",

--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -43,6 +43,10 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
 
   const numEvents = inputNumEvents ?? Math.min(events.length, DEFAULT_MAX_EVENTS);
 
+  // Call onClose when the component is unmounted
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => onClose, []);
+
   React.useEffect(() => {
     if (kind && name && namespace) {
       const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -70,8 +74,12 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
         setError(t('Error loading events from WebSocket'));
       };
 
-      return () => {
+      socket.onclose = () => {
+        setError(undefined);
         setIsLoading(false);
+      };
+
+      return () => {
         socket.close();
       };
     }
@@ -129,7 +137,7 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
           <Alert
             className="ols-plugin__alert"
             isInline
-            title={t('Failed to attach context')}
+            title={t('Failed to load events')}
             variant="danger"
           >
             {error}

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -235,6 +235,10 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
     }
   };
 
+  // Call onClose when the component is unmounted
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => onClose, []);
+
   // When the resource changes, reset the default pod (and container) options
   React.useEffect(() => {
     changePod(kind === 'Pod' ? resource : undefined);

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -479,7 +479,7 @@ const AttachMenu: React.FC<AttachMenuProps> = ({ context }) => {
 
   return (
     <>
-      {showEvents && context && (
+      {showEvents && context && context.metadata?.uid && (
         <AttachEventsModal
           isOpen={isEventsModalOpen}
           kind={kind}


### PR DESCRIPTION
Because these modals didn't call `onClose` when the components unmounted (e.g.  when you hit the browser back button to leave the page), the `isOpen` flag continued to be `true`. That meant that if you later returned to a page with the same modal (another pod details page), the modal would unexpectedly open.

Also makes sure we clear the attach events modal's `error` and `isLoading` state if the resource context changes. Currently, this shouldn't matter since changing the resource context only happens when you navigate to a different page, which would unmount the modal and clear the state anyway. However, it might be possible in the future.