### PR TITLE
OLS-998: Enable attach events functionality for additional k8s resource types

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -472,7 +472,16 @@ const AttachMenu: React.FC<AttachMenuProps> = ({ context }) => {
     [isOpen, t, toggleIsOpen],
   );
 
-  const showEvents = kind === 'Pod';
+  const showEvents = [
+    'CronJob',
+    'DaemonSet',
+    'Deployment',
+    'Job',
+    'Pod',
+    'ReplicaSet',
+    'StatefulSet',
+  ].includes(kind);
+
   const showLogs = ['DaemonSet', 'Deployment', 'Job', 'Pod', 'ReplicaSet', 'StatefulSet'].includes(
     kind,
   );


### PR DESCRIPTION
Enabled for the same set of resource types that have the attach YAML functionality (Pod, Job, CronJob, Deployment, DaemonSet, ReplicaSet and StatefulSet).