### PR TITLE
Disable "Events" in attach menu if there are no events

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -357,6 +357,9 @@ const AttachMenu: React.FC<AttachMenuProps> = ({ context }) => {
 
   const dispatch = useDispatch();
 
+  const events = useSelector((s: State) => s.plugins?.ols?.get('contextEvents'));
+  const isEventsLoading = useSelector((s: State) => s.plugins?.ols?.get('isContextEventsLoading'));
+
   const [error, setError] = React.useState<string>();
   const [isEventsModalOpen, , openEventsModal, closeEventsModal] = useBoolean(false);
   const [isLogModalOpen, , openLogModal, closeLogModal] = useBoolean(false);
@@ -538,9 +541,16 @@ const AttachMenu: React.FC<AttachMenuProps> = ({ context }) => {
                     <FileCodeIcon /> YAML <Chip isReadOnly>status</Chip> {t('only')}
                   </SelectOption>
                   {showEvents && (
-                    <SelectOption value={AttachmentTypes.Events}>
-                      <TaskIcon /> {t('Events')}
-                    </SelectOption>
+                    <div
+                      title={!isEventsLoading && events.length === 0 ? t('No events') : undefined}
+                    >
+                      <SelectOption
+                        isDisabled={!isEventsLoading && events.length === 0}
+                        value={AttachmentTypes.Events}
+                      >
+                        <TaskIcon /> {t('Events')}
+                      </SelectOption>
+                    </div>
                   )}
                   {showLogs && (
                     <SelectOption value={AttachmentTypes.Log}>

--- a/src/redux-actions.ts
+++ b/src/redux-actions.ts
@@ -3,17 +3,20 @@ import { action, ActionType as Action } from 'typesafe-actions';
 import { Attachment, ChatEntry } from './types';
 
 export enum ActionType {
+  AddContextEvent = 'addContextEvent',
   AttachmentDelete = 'attachmentDelete',
   AttachmentsClear = 'attachmentsClear',
   AttachmentSet = 'attachmentSet',
   ChatHistoryClear = 'chatHistoryClear',
   ChatHistoryPush = 'chatHistoryPush',
+  ClearContextEvents = 'clearContextEvents',
   CloseOLS = 'closeOLS',
   OpenAttachmentClear = 'openAttachmentClear',
   OpenAttachmentSet = 'openAttachmentSet',
   OpenOLS = 'openOLS',
   SetContext = 'setContext',
   SetConversationID = 'setConversationID',
+  SetIsContextEventsLoading = 'setIsContextEventsLoading',
   SetQuery = 'setQuery',
   UserFeedbackClose = 'userFeedbackClose',
   UserFeedbackDisable = 'userFeedbackDisable',
@@ -21,6 +24,8 @@ export enum ActionType {
   UserFeedbackSetSentiment = 'userFeedbackSetSentiment',
   UserFeedbackSetText = 'userFeedbackSetText',
 }
+
+export const addContextEvent = (event: object) => action(ActionType.AddContextEvent, { event });
 
 export const attachmentDelete = (id: string) => action(ActionType.AttachmentDelete, { id });
 
@@ -49,6 +54,8 @@ export const chatHistoryClear = () => action(ActionType.ChatHistoryClear);
 
 export const chatHistoryPush = (entry: ChatEntry) => action(ActionType.ChatHistoryPush, { entry });
 
+export const clearContextEvents = () => action(ActionType.ClearContextEvents);
+
 export const closeOLS = () => action(ActionType.CloseOLS);
 
 export const openAttachmentClear = () => action(ActionType.OpenAttachmentClear);
@@ -61,6 +68,9 @@ export const openOLS = () => action(ActionType.OpenOLS);
 export const setContext = (context: object) => action(ActionType.SetContext, { context });
 
 export const setConversationID = (id: string) => action(ActionType.SetConversationID, { id });
+
+export const setIsContextEventsLoading = (isLoading: boolean) =>
+  action(ActionType.SetIsContextEventsLoading, { isLoading });
 
 export const setQuery = (query: string) => action(ActionType.SetQuery, { query });
 
@@ -80,17 +90,20 @@ export const userFeedbackSetText = (entryIndex: number, text: string) =>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const actions = {
+  addContextEvent,
   attachmentDelete,
   attachmentsClear,
   attachmentSet,
   chatHistoryClear,
   chatHistoryPush,
+  clearContextEvents,
   closeOLS,
   openAttachmentClear,
   openAttachmentSet,
   openOLS,
   setContext,
   setConversationID,
+  setIsContextEventsLoading,
   setQuery,
   userFeedbackClose,
   userFeedbackDisable,

--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -18,7 +18,9 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
       attachments: ImmutableMap<string, Attachment>(),
       chatHistory: ImmutableList(),
       context: null,
+      contextEvents: [],
       conversationID: null,
+      isContextEventsLoading: false,
       isOpen: false,
       isUserFeedbackEnabled: true,
       openAttachment: null,
@@ -27,6 +29,14 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
   }
 
   switch (action.type) {
+    case ActionType.AddContextEvent: {
+      const oldEvents = state.get('contextEvents');
+      return state.set(
+        'contextEvents',
+        oldEvents ? [...oldEvents, action.payload.event] : [action.payload.event],
+      );
+    }
+
     case ActionType.AttachmentDelete:
       return state.deleteIn(['attachments', action.payload.id]);
 
@@ -47,6 +57,9 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
         state.get('chatHistory').push(ImmutableMap(action.payload.entry)),
       );
 
+    case ActionType.ClearContextEvents:
+      return state.set('contextEvents', []);
+
     case ActionType.CloseOLS:
       return state.set('isOpen', false);
 
@@ -61,6 +74,9 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
 
     case ActionType.SetContext:
       return state.set('context', action.payload.context);
+
+    case ActionType.SetIsContextEventsLoading:
+      return state.set('isContextEventsLoading', action.payload.isLoading);
 
     case ActionType.SetConversationID:
       return state.set('conversationID', action.payload.id);


### PR DESCRIPTION
Store the events data in redux so it can be shared between components.