### PR TITLE
Reduce some API fetch timeouts

### DIFF
--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -36,7 +36,6 @@ import CopyAction from './CopyAction';
 import Modal from './Modal';
 
 const DEFAULT_LOG_LINES = 25;
-const REQUEST_TIMEOUT = 10 * 60 * 1000; // 10 minutes
 
 type ContainerInputProps = {
   containers: string[];
@@ -279,7 +278,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
     debounce((url: string) => {
       setIsPreviewLoading(true);
       setPreviewError(undefined);
-      consoleFetchText(url, getRequestInitWithAuthHeader(), REQUEST_TIMEOUT)
+      consoleFetchText(url, getRequestInitWithAuthHeader())
         .then((response: string) => {
           setPreview(response);
           setIsPreviewLoading(false);
@@ -309,7 +308,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
       const url = `/api/kubernetes/api/v1/namespaces/${namespace}/pods/${podName}/log?container=${container}&tailLines=${lines}`;
       setIsLoading(true);
       setError(undefined);
-      consoleFetchText(url, getRequestInitWithAuthHeader(), REQUEST_TIMEOUT)
+      consoleFetchText(url, getRequestInitWithAuthHeader())
         .then((response: string) => {
           setIsLoading(false);
           dispatch(

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -38,7 +38,7 @@ import ErrorBoundary from './ErrorBoundary';
 
 const USER_FEEDBACK_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/feedback';
 
-const REQUEST_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+const REQUEST_TIMEOUT = 5 * 60 * 1000;
 
 const THUMBS_DOWN = -1;
 const THUMBS_UP = 1;

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -85,7 +85,7 @@ import './general-page.css';
 const QUERY_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/query';
 const ALERTS_ENDPOINT = '/api/prometheus/api/v1/rules?type=alert';
 
-const REQUEST_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+const QUERY_REQUEST_TIMEOUT = 10 * 60 * 1000; // 10 minutes
 
 type QueryResponse = {
   conversation_id: string;
@@ -386,7 +386,7 @@ const AttachMenu: React.FC<AttachMenuProps> = ({ context }) => {
       } else if (kind === 'Alert') {
         setLoading();
         const labels = Object.fromEntries(new URLSearchParams(location.search));
-        consoleFetchJSON(ALERTS_ENDPOINT, 'get', getRequestInitWithAuthHeader(), REQUEST_TIMEOUT)
+        consoleFetchJSON(ALERTS_ENDPOINT, 'get', getRequestInitWithAuthHeader())
           .then((response) => {
             let alert;
             each(response?.data?.groups, (group) => {
@@ -693,7 +693,7 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
       };
 
       consoleFetchJSON
-        .post(QUERY_ENDPOINT, requestJSON, getRequestInitWithAuthHeader(), REQUEST_TIMEOUT)
+        .post(QUERY_ENDPOINT, requestJSON, getRequestInitWithAuthHeader(), QUERY_REQUEST_TIMEOUT)
         .then((response: QueryResponse) => {
           dispatch(setConversationID(response.conversation_id));
           dispatch(


### PR DESCRIPTION
- Don't specifiy a timeout for loading alerts and container logs (use the Console's default timeout, which is currently 60 seconds)
- Reduce user feedback timeout to 5 minutes