### PR TITLE
Fix bug where attach menu could be open even when disabled

### DIFF
--- a/src/components/AttachMenu.tsx
+++ b/src/components/AttachMenu.tsx
@@ -153,7 +153,7 @@ const AttachMenu: React.FC<AttachMenuProps> = ({ context }) => {
           <MenuToggle
             className="ols-plugin__attach-menu"
             isDisabled={isDisabled}
-            isExpanded={isOpen}
+            isExpanded={isOpen && !isDisabled}
             onClick={toggleIsOpen}
             ref={toggleRef}
             variant="plain"


### PR DESCRIPTION
If you opened the attach menu, then used the browser back button to go to a page where the attach menu is disabled, the menu would remain open. This fixes it to automatically close in that case.