### PR TITLE
OLS-1143: Add preview to the attach events modal

### DIFF
--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -384,7 +384,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
                 </CodeBlockAction>
               </>
             }
-            className="ols-plugin__code-block ols-plugin__code-block--logs-preview"
+            className="ols-plugin__code-block ols-plugin__code-block--preview"
           >
             {isPreviewLoading && <Spinner size="md" />}
             {previewError && <Error title={t('Failed to load preview')}>{previewError}</Error>}

--- a/src/components/general-page.css
+++ b/src/components/general-page.css
@@ -82,7 +82,7 @@
   max-height: 24rem;
 }
 
-.ols-plugin__code-block--logs-preview {
+.ols-plugin__code-block--preview {
   height: 14rem;
   margin-top: 1rem;
   max-height: unset;


### PR DESCRIPTION
Before attaching events to the prompt, you can now preview what will be attached in the modal.