### PR TITLE
OLS-1157: Always render the popover button with the Button component

### DIFF
--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -72,7 +72,12 @@ const Popover: React.FC = () => {
               <GeneralPage onClose={close} onExpand={expand} />
             )}
           </div>
-          <div className="ols-plugin__popover-button" onClick={close}></div>
+          <Button
+            aria-label={title}
+            className="ols-plugin__popover-button"
+            onClick={close}
+            variant="link"
+          />
         </>
       ) : (
         <Tooltip content={title}>


### PR DESCRIPTION
The Button component was only being used when the popover UI was closed. This changes it so that a Button is always used regardless of whether the popover UI is open or closed.