### PR TITLE
Reenable source image builds now that KFLUXBUGS-1508 is fixed

### DIFF
--- a/.tekton/lightspeed-console-pull-request.yaml
+++ b/.tekton/lightspeed-console-pull-request.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/lightspeed-console-push.yaml
+++ b/.tekton/lightspeed-console-push.yaml
@@ -110,7 +110,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
Reenable source image builds now that [KFLUXBUGS-1508](https://issues.redhat.com//browse/KFLUXBUGS-1508) is fixed