### PR TITLE
OLS-1250: Remove the isRequired option for inputs that have a default value

### DIFF
--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -143,7 +143,7 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
             </HelperText>
           ) : (
             <>
-              <FormGroup isRequired label={t('Most recent {{numEvents}} events', { numEvents })}>
+              <FormGroup label={t('Most recent {{numEvents}} events', { numEvents })}>
                 <Slider
                   max={events.length}
                   min={1}

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -346,7 +346,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
       </Text>
       <Form>
         {showPodInput && (
-          <FormGroup isRequired label="Pod">
+          <FormGroup label="Pod">
             {podsError && <Error title={t('Failed to load pods')}>{podsError}</Error>}
             {podsLoaded ? (
               pods.length === 0 ? (
@@ -368,14 +368,14 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
         )}
         {(!showPodInput || (podsLoaded && pods.length > 0)) && (
           <>
-            <FormGroup isRequired label="Container">
+            <FormGroup label="Container">
               <ContainerInput
                 containers={containers}
                 selectedContainer={container}
                 setContainer={setContainer}
               />
             </FormGroup>
-            <FormGroup isRequired label={t('Most recent {{lines}} lines', { lines })}>
+            <FormGroup label={t('Most recent {{lines}} lines', { lines })}>
               <Slider max={100} min={1} onChange={onLinesChange} value={lines} />
             </FormGroup>
           </>


### PR DESCRIPTION
It is not possible to leave these inputs empty, so it doesn't makes sense to add the isRequired indicator.