### PR TITLE
OLS-1251: Add ticks to attach events slider

### DIFF
--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -148,6 +148,7 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
                   max={events.length}
                   min={1}
                   onChange={onInputNumEventsChange}
+                  showTicks={events.length <= 40}
                   value={numEvents}
                 />
               </FormGroup>


### PR DESCRIPTION
Don't show the ticks if there will be too many because they get too squashed together and it's not clear that they are ticks.