### PR TITLE
ODC-7711: Add Telemetry to the OLS Import to Console feature

### DIFF
--- a/src/components/ImportAction.tsx
+++ b/src/components/ImportAction.tsx
@@ -43,6 +43,7 @@ const ImportAction: React.FC<Props> = ({ value }) => {
       importCodeBlock({
         value,
         id: _.uniqueId('ImportCodeBlock_'),
+        triggeredFrom: location?.pathname,
       }),
     );
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,4 +38,5 @@ export type ChatEntry = ChatEntryAI | ChatEntryUser;
 export type CodeBlock = {
   id: string;
   value: string;
+  triggeredFrom?: string;
 };


### PR DESCRIPTION
**_Note: PR openshift/console#14562 is dependant on this PR._**

**Type**: 

- [ ] Bug Fix
- [x] New Feature

**Jira Link**: 

1. https://issues.redhat.com/browse/ODC-7711

**Solution Description**: 

This pull request includes changes to the `ImportAction` component and the `CodeBlock` type to track the source of code block imports. The most important changes are:

Enhancements to `ImportAction` component:

* [`src/components/ImportAction.tsx`](diffhunk://#diff-3ff6eed62347452b46e32a856ba102a861b068f556b5c9220bb76cb47588589fR46): Added a `triggeredFrom` property to the `importCodeBlock` function call to track the pathname from which the import was triggered.

Updates to `CodeBlock` type:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR41): Added an optional `triggeredFrom` property to the `CodeBlock` type to store the pathname information.

**Test setup:**

1. Install OLS Plugin
2. Import a code to the console
3. Telemetry will be fired.

**Browser conformance**: 

- [x] Chrome
- [ ] Firefox
- [ ] Safari