### PR TITLE
OLS-1077: Add attach logs option for HPAs

### DIFF
--- a/locales/en/plugin__lightspeed-console-plugin.json
+++ b/locales/en/plugin__lightspeed-console-plugin.json
@@ -38,6 +38,7 @@
   "Failed to load events": "Failed to load events",
   "Failed to load pods": "Failed to load pods",
   "Failed to load preview": "Failed to load preview",
+  "Failed to load scale target": "Failed to load scale target",
   "Good response": "Good response",
   "History truncated": "History truncated",
   "If this error persists, please contact an administrator. Error details: {{e}}": "If this error persists, please contact an administrator. Error details: {{e}}",

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -361,7 +361,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
           <>
             {showPodInput && (
               <FormGroup label="Pod">
-                {podsError && <Error title={t('Failed to load pods')}>{podsError}</Error>}
+                {podsError && <Error title={t('Failed to load pods')}>{podsError.message}</Error>}
                 {podsLoaded ? (
                   pods.length === 0 ? (
                     <Alert

--- a/src/components/AttachMenu.tsx
+++ b/src/components/AttachMenu.tsx
@@ -192,6 +192,7 @@ const AttachMenu: React.FC = () => {
   const showLogs = [
     'DaemonSet',
     'Deployment',
+    'HorizontalPodAutoscaler',
     'Job',
     'kubevirt.io~v1~VirtualMachine',
     'kubevirt.io~v1~VirtualMachineInstance',


### PR DESCRIPTION
Actually adds the logs for the HPA's `scaleTargetRef` resource.

Also fixes display of error message when the pods fail to load in the attach logs modal.