### PR TITLE
config: konflux pipeline nudges related_images.json

### DIFF
--- a/.tekton/lightspeed-console-push.yaml
+++ b/.tekton/lightspeed-console-push.yaml
@@ -8,6 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
+    build.appstudio.openshift.io/build-nudge-files: |
+      .*Dockerfile.*, ^(?!lightspeed-catalog.*\/).*\.yaml$, .*Containerfile.*, related_images.json
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols


### PR DESCRIPTION
bundle image references are stored in related_images.json in operator repository now. So we should nudge that file to update the bundle.