### PR TITLE
OLS-1351: Fix YAML import option to only be shown on 4.18+

### DIFF
--- a/src/components/ImportAction.tsx
+++ b/src/components/ImportAction.tsx
@@ -24,6 +24,15 @@ const ImportAction: React.FC<Props> = ({ value }) => {
 
   const [showModal, setShowModal] = React.useState(false);
 
+  // The web console only supports the import YAML action from version 4.18
+  const { releaseVersion } = window.SERVER_FLAGS;
+  if (releaseVersion) {
+    const [major, minor] = releaseVersion.split('.');
+    if (Number(major) < 4 || (Number(major) === 4 && Number(minor) < 18)) {
+      return null;
+    }
+  }
+
   const handleRedirect = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (event.currentTarget.id === 'leave') {
       history.push(`/k8s/ns/${activeNamespace}/import?ols=true`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,14 @@ import { Map as ImmutableMap } from 'immutable';
 
 import { ErrorType } from './error';
 
+declare global {
+  interface Window {
+    SERVER_FLAGS: {
+      releaseVersion: string;
+    };
+  }
+}
+
 export type Attachment = {
   attachmentType: string;
   isEditable?: boolean;


### PR DESCRIPTION
Support for this feature was only added to the web console in version 4.18