### PR TITLE
OLS-1490: Fix bug seen when submiting a prompt while a response is streaming

### DIFF
--- a/src/redux-actions.ts
+++ b/src/redux-actions.ts
@@ -9,7 +9,7 @@ export enum ActionType {
   AttachmentSet = 'attachmentSet',
   ChatHistoryClear = 'chatHistoryClear',
   ChatHistoryPush = 'chatHistoryPush',
-  ChatHistoryUpdateLast = 'chatHistoryUpdateLast',
+  chatHistoryUpdateByID = 'chatHistoryUpdateByID',
   ClearContextEvents = 'clearContextEvents',
   CloseOLS = 'closeOLS',
   OpenAttachmentClear = 'openAttachmentClear',
@@ -55,8 +55,8 @@ export const chatHistoryClear = () => action(ActionType.ChatHistoryClear);
 
 export const chatHistoryPush = (entry: ChatEntry) => action(ActionType.ChatHistoryPush, { entry });
 
-export const chatHistoryUpdateLast = (entry: Partial<ChatEntry>) =>
-  action(ActionType.ChatHistoryUpdateLast, { entry });
+export const chatHistoryUpdateByID = (id: string, entry: Partial<ChatEntry>) =>
+  action(ActionType.chatHistoryUpdateByID, { entry, id });
 
 export const clearContextEvents = () => action(ActionType.ClearContextEvents);
 
@@ -100,7 +100,7 @@ const actions = {
   attachmentSet,
   chatHistoryClear,
   chatHistoryPush,
-  chatHistoryUpdateLast,
+  chatHistoryUpdateByID,
   clearContextEvents,
   closeOLS,
   importCodeBlock,

--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -60,9 +60,11 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
     case ActionType.ChatHistoryClear:
       return state.set('chatHistory', ImmutableList());
 
-    case ActionType.ChatHistoryUpdateLast: {
-      const lastKey = state.get('chatHistory').keySeq().last();
-      return state.mergeIn(['chatHistory', lastKey], action.payload.entry);
+    case ActionType.chatHistoryUpdateByID: {
+      const index = state
+        .get('chatHistory')
+        .findIndex((entry) => entry.get('id') === action.payload.id);
+      return state.mergeIn(['chatHistory', index], action.payload.entry);
     }
 
     case ActionType.ChatHistoryPush:

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ type ChatEntryUser = {
 
 type ChatEntryAI = {
   error?: ErrorType;
+  id: string;
   isStreaming: boolean;
   isTruncated: boolean;
   references?: Array<ReferencedDoc>;


### PR DESCRIPTION
If you submitted a prompt while the previous response was still streaming, that previous response would get split across two entries in the chat.