### PR TITLE
OLS-1516: Fix reference doc links

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -117,13 +117,17 @@ type DocLinkProps = {
 };
 
 const DocLink: React.FC<DocLinkProps> = ({ reference }) => {
-  if (!reference || typeof reference.docs_url !== 'string' || typeof reference.title !== 'string') {
+  if (
+    !reference ||
+    typeof reference.doc_title !== 'string' ||
+    typeof reference.doc_url !== 'string'
+  ) {
     return null;
   }
 
   return (
     <Chip isReadOnly textMaxWidth="16rem">
-      <ExternalLink href={reference.docs_url}>{reference.title}</ExternalLink>
+      <ExternalLink href={reference.doc_url}>{reference.doc_title}</ExternalLink>
     </Chip>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export type Attachment = {
 };
 
 export type ReferencedDoc = {
-  docs_url: string;
-  title: string;
+  doc_title: string;
+  doc_url: string;
 };
 
 type ChatEntryUser = {


### PR DESCRIPTION
With the introduction of streaming, the response format changed from
  `{"title": "...", "docs_url": "..."}`
to
  `{"doc_title": "...", "doc_url": "..."}`