### PR TITLE
OLS-1491: Remove auto-scroll when feedback button is clicked

### DIFF
--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -46,10 +46,9 @@ const THUMBS_UP = 1;
 type Props = {
   conversationID: string;
   entryIndex: number;
-  scrollIntoView: () => void;
 };
 
-const Feedback: React.FC<Props> = ({ conversationID, entryIndex, scrollIntoView }) => {
+const Feedback: React.FC<Props> = ({ conversationID, entryIndex }) => {
   const { t } = useTranslation('plugin__lightspeed-console-plugin');
 
   const dispatch = useDispatch();
@@ -85,14 +84,12 @@ const Feedback: React.FC<Props> = ({ conversationID, entryIndex, scrollIntoView 
     dispatch(
       userFeedbackSetSentiment(entryIndex, sentiment === THUMBS_DOWN ? undefined : THUMBS_DOWN),
     );
-    scrollIntoView();
-  }, [dispatch, entryIndex, scrollIntoView, sentiment]);
+  }, [dispatch, entryIndex, sentiment]);
 
   const onThumbsUp = React.useCallback(() => {
     dispatch(userFeedbackOpen(entryIndex));
     dispatch(userFeedbackSetSentiment(entryIndex, sentiment === THUMBS_UP ? undefined : THUMBS_UP));
-    scrollIntoView();
-  }, [dispatch, entryIndex, scrollIntoView, sentiment]);
+  }, [dispatch, entryIndex, sentiment]);
 
   const onTextChange = React.useCallback(
     (_e, newText) => {
@@ -199,17 +196,9 @@ const Feedback: React.FC<Props> = ({ conversationID, entryIndex, scrollIntoView 
   );
 };
 
-const FeedbackWithErrorBoundary: React.FC<Props> = ({
-  conversationID,
-  entryIndex,
-  scrollIntoView,
-}) => (
+const FeedbackWithErrorBoundary: React.FC<Props> = ({ conversationID, entryIndex }) => (
   <ErrorBoundary>
-    <Feedback
-      conversationID={conversationID}
-      entryIndex={entryIndex}
-      scrollIntoView={scrollIntoView}
-    />
+    <Feedback conversationID={conversationID} entryIndex={entryIndex} />
   </ErrorBoundary>
 );
 

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -156,14 +156,12 @@ type ChatHistoryEntryProps = {
   conversationID: string;
   entry: ChatEntry;
   entryIndex: number;
-  scrollIntoView: () => void;
 };
 
 const ChatHistoryEntry: React.FC<ChatHistoryEntryProps> = ({
   conversationID,
   entry,
   entryIndex,
-  scrollIntoView,
 }) => {
   const { t } = useTranslation('plugin__lightspeed-console-plugin');
 
@@ -212,11 +210,7 @@ const ChatHistoryEntry: React.FC<ChatHistoryEntryProps> = ({
               </ChipGroup>
             )}
             {isUserFeedbackEnabled && !entry.isStreaming && (
-              <Feedback
-                conversationID={conversationID}
-                entryIndex={entryIndex}
-                scrollIntoView={scrollIntoView}
-              />
+              <Feedback conversationID={conversationID} entryIndex={entryIndex} />
             )}
           </>
         )}
@@ -574,13 +568,7 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
         <AuthAlert authStatus={authStatus} />
         <PrivacyAlert />
         {chatHistory.toJS().map((entry, i) => (
-          <ChatHistoryEntry
-            conversationID={conversationID}
-            entry={entry}
-            entryIndex={i}
-            key={i}
-            scrollIntoView={scrollIntoView}
-          />
+          <ChatHistoryEntry conversationID={conversationID} entry={entry} entryIndex={i} key={i} />
         ))}
         <ReadinessAlert />
         <div ref={chatHistoryEndRef} />


### PR DESCRIPTION
Removing this because the auto-scroll had UX issues and also because the implementation was incorrect for responses other than the most recent.