### PR TITLE
Fix EC violations, add 2 tasks to konflux pipeline

### DIFF
--- a/.tekton/lightspeed-console-pull-request.yaml
+++ b/.tekton/lightspeed-console-pull-request.yaml
@@ -395,6 +395,56 @@ spec:
         operator: in
         values:
         - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:8e817af22b04305676597a556a975bde8552949ca2bf8918bf62414f135f93c8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:b9c3dfe732a0d9581c75d07d59043f675ddcbe5e9a3152daad99076bedfd5b85
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"        
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/lightspeed-console-push.yaml
+++ b/.tekton/lightspeed-console-push.yaml
@@ -394,6 +394,56 @@ spec:
         operator: in
         values:
         - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:8e817af22b04305676597a556a975bde8552949ca2bf8918bf62414f135f93c8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:b9c3dfe732a0d9581c75d07d59043f675ddcbe5e9a3152daad99076bedfd5b85
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"   
     - name: clamav-scan
       params:
       - name: image-digest


### PR DESCRIPTION
config: add to konflux pipeline: sast-shell-check-oci-ta, sast-unicode-check-oci-ta

This fixes the EC violation below:
```
✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:d8571ce72d6de777ebb22954a3e853b503da693fc444330af1220f0951fcaade
  Reason: One of "sast-unicode-check", "sast-unicode-check-oci-ta" tasks is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:sast-unicode-check", "tasks.required_tasks_found:sast-unicode-check-oci-ta" to the `exclude`
  section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  https://conforma.dev/docs/ec-cli/configuration.html#_data_sources under the key 'required-tasks'.

✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:d77eba492f094d40cb9d9c2b50bca333fdf109f02cf5c386467b5cf4e27ac132
  Reason: One of "sast-shell-check", "sast-shell-check-oci-ta" tasks is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:sast-shell-check", "tasks.required_tasks_found:sast-shell-check-oci-ta" to the `exclude`
  section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  https://conforma.dev/docs/ec-cli/configuration.html#_data_sources under the key 'required-tasks'.
```