### PR TITLE
Remove project specific ref from alert message

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -318,7 +318,7 @@ const PrivacyAlert: React.FC = () => {
   return (
     <Alert className="ols-plugin__alert" isInline title={t('Important')} variant="info">
       {t(
-        "OpenShift Lightspeed can answer questions related to OpenShift. This feature uses AI technology. Do not include personal information or other sensitive information in your input. Interactions may be used to improve Red Hat's products or services.",
+        "OpenShift Lightspeed uses AI technology to help answer your questions. Do not include personal information or other sensitive information in your input. Interactions may be used to improve Red Hat's products or services.",
       )}
     </Alert>
   );


### PR DESCRIPTION
With the inclusion of OpenStack on top of the OpenShift Lightspeed and maybe more projects in the future, it's important to make these alert messages project agnostic.

This commit refactors the alert message to remove any project specific references.