### PR TITLE
konflux nudge: console does not nudge catalog.

### DIFF
--- a/.tekton/lightspeed-console-push.yaml
+++ b/.tekton/lightspeed-console-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: |
-      .*Dockerfile.*, ^(?!lightspeed-catalog.*\/).*\.yaml$, .*Containerfile.*, related_images.json
+      .*Dockerfile.*, .*Containerfile.*, related_images.json
     build.appstudio.openshift.io/repo: https://github.com/openshift/lightspeed-console?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
Console image update does not nudge the catalog, because the catalog should be generated from bundle.