### PR TITLE
OLS-1748: Style fix for chat history "Context" on OpenShift 4.19

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -272,14 +272,12 @@ const ChatHistoryEntry: React.FC<ChatHistoryEntryProps> = ({
         {entry.attachments && Object.keys(entry.attachments).length > 0 && (
           <ExpandableSection
             className="ols-plugin__chat-history-context"
+            displaySize="lg"
             isExpanded={isContextExpanded}
             onToggle={toggleContextExpanded}
             toggleContent={
               <>
-                Context
-                <Badge className="ols-plugin__chat-history-context-count">
-                  {Object.keys(entry.attachments).length}
-                </Badge>
+                Context <Badge>{Object.keys(entry.attachments).length}</Badge>
               </>
             }
           >

--- a/src/components/general-page.css
+++ b/src/components/general-page.css
@@ -66,10 +66,6 @@
   padding: var(--pf-global--spacer--sm);
 }
 
-.ols-plugin__chat-history-context-count {
-  margin-left: var(--pf-global--spacer--sm);
-}
-
 .ols-plugin__code-block {
   margin: 1rem 0;
   overflow: hidden;


### PR DESCRIPTION
Minor style fix to improve the display on 4.19 without significantly changing the display in earlier versions.