### PR TITLE
OLS-1770: Add writable volumes to compensate for read-only root fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ LABEL name="openshift-lightspeed/lightspeed-console" \
       io.openshift.tags="openshift-lightspeed,ols"
 USER 1001
 
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["nginx", "-g", "daemon off;", "-e", "stderr"]


### PR DESCRIPTION
Directed to stderr the nginx logs that are emitted before the nginx.conf config file is parsed. This is part of the switch to the read-only root filesystems for all the operands in the OLS operator, specifically to avoid the 
```
nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (30: Read-only file system)
```
alert.