### PR TITLE
Simplify OLS API setup for development environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-export REACT_BEARER_TOKEN=<<token>>

--- a/README.md
+++ b/README.md
@@ -36,17 +36,23 @@ This will run the OpenShift console in a container connected to the cluster
 you've logged into. The plugin HTTP server runs on port 9001 with CORS enabled.
 Navigate to <http://localhost:9000> to see the running plugin.
 
+For the OLS API calls to succeed, you need to set the `OLS_API_BEARER_TOKEN`
+environment variable to a valid bearer token.
+
 #### Using a localhost backend
 
-If your Lightspeed service is running on your local machine, you can test locally by updating the UI to call localhost and running Chrome with CORS disabled.
+If your Lightspeed service is running on your local machine, you can test
+locally by running Chrome with CORS disabled.
 
-1. Change the query endpoint in `src/components/GeneralPage.tsx`:
+1. Set the `OLS_API_BASE_URL` environment variable when starting the development server.
 
-   ```ts
-   const QUERY_ENDPOINT = 'http://127.0.0.1:8080/v1/streaming_query';
+   ```bash
+   OLS_API_BASE_URL='http://127.0.0.1:8080' npm run start
    ```
 
-2. Start Chrome with web security disabled so localhost requests don't fail due to CORS. ⚠️ WARNING: This disables Chrome security, so only use these flags for local development!
+2. Start Chrome with web security disabled so localhost requests don't fail due
+to CORS. ⚠️ WARNING: This disables Chrome security, so only use these flags for
+local development!
 
    - macOS:
      ```bash

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as _ from 'lodash';
 
+import { getApiUrl } from '../../src/config';
+
 import Loggable = Cypress.Loggable;
 import Timeoutable = Cypress.Timeoutable;
 import Withinable = Cypress.Withinable;
@@ -225,23 +227,19 @@ Cypress.Commands.add(
     conversationId: string | null = null,
     attachments: Array<Attachment> = [],
   ) => {
-    cy.intercept(
-      'POST',
-      '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/streaming_query',
-      (request) => {
-        expect(request.body.media_type).to.equal('application/json');
-        expect(request.body.conversation_id).to.equal(conversationId);
-        expect(request.body.query).to.equal(query);
+    cy.intercept('POST', getApiUrl('/v1/streaming_query'), (request) => {
+      expect(request.body.media_type).to.equal('application/json');
+      expect(request.body.conversation_id).to.equal(conversationId);
+      expect(request.body.query).to.equal(query);
 
-        expect(request.body.attachments).to.have.lengthOf(attachments.length);
-        attachments.forEach((a, i) => {
-          expect(request.body.attachments[i].attachment_type).to.equal(a.attachment_type);
-          expect(request.body.attachments[i].content_type).to.equal(a.content_type);
-        });
+      expect(request.body.attachments).to.have.lengthOf(attachments.length);
+      attachments.forEach((a, i) => {
+        expect(request.body.attachments[i].attachment_type).to.equal(a.attachment_type);
+        expect(request.body.attachments[i].content_type).to.equal(a.content_type);
+      });
 
-        request.reply({ body: MOCK_STREAMED_RESPONSE_BODY, delay: 1000 });
-      },
-    ).as(alias);
+      request.reply({ body: MOCK_STREAMED_RESPONSE_BODY, delay: 1000 });
+    }).as(alias);
   },
 );
 
@@ -256,22 +254,18 @@ Cypress.Commands.add(
     userFeedback: string,
     userQuestionStartsWith: string,
   ) => {
-    cy.intercept(
-      'POST',
-      '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/feedback',
-      (request) => {
-        expect(_.omit(request.body, 'user_question')).to.deep.equal({
-          /* eslint-disable camelcase */
-          conversation_id: conversationId,
-          sentiment,
-          user_feedback: userFeedback,
-          llm_response: 'Mock OLS response',
-          /* eslint-enable camelcase */
-        });
-        expect(request.body.user_question.startsWith(userQuestionStartsWith)).to.equal(true);
+    cy.intercept('POST', getApiUrl('/v1/feedback'), (request) => {
+      expect(_.omit(request.body, 'user_question')).to.deep.equal({
+        /* eslint-disable camelcase */
+        conversation_id: conversationId,
+        sentiment,
+        user_feedback: userFeedback,
+        llm_response: 'Mock OLS response',
+        /* eslint-enable camelcase */
+      });
+      expect(request.body.user_question.startsWith(userQuestionStartsWith)).to.equal(true);
 
-        request.reply(USER_FEEDBACK_MOCK_RESPONSE);
-      },
-    ).as(alias);
+      request.reply(USER_FEEDBACK_MOCK_RESPONSE);
+    }).as(alias);
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@patternfly/react-icons": "5.4.2",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
-        "dotenv": "^17.2.2",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "react": "17.0.2",
@@ -6393,18 +6392,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@patternfly/react-icons": "5.4.2",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
-    "dotenv": "^17.2.2",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "react": "17.0.2",

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -30,7 +30,6 @@ import {
 
 import { AttachmentTypes } from '../attachments';
 import { useBoolean } from '../hooks/useBoolean';
-import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import { attachmentSet } from '../redux-actions';
 import CopyAction from './CopyAction';
 import Modal from './Modal';
@@ -293,7 +292,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
     debounce((url: string) => {
       setIsPreviewLoading(true);
       setPreviewError(undefined);
-      consoleFetchText(url, getRequestInitWithAuthHeader())
+      consoleFetchText(url)
         .then((response) => {
           if (isEmpty(response) || typeof response !== 'string') {
             setPreviewError(t('No logs found'));
@@ -327,7 +326,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
       const url = `/api/kubernetes/api/v1/namespaces/${namespace}/pods/${podName}/log?container=${container}&tailLines=${lines}`;
       setIsLoading(true);
       setError(undefined);
-      consoleFetchText(url, getRequestInitWithAuthHeader())
+      consoleFetchText(url)
         .then((response: string) => {
           setIsLoading(false);
           if (isEmpty(response) || typeof response !== 'string') {

--- a/src/components/AttachMenu.tsx
+++ b/src/components/AttachMenu.tsx
@@ -30,7 +30,6 @@ import {
 } from '@patternfly/react-icons';
 
 import { AttachmentTypes } from '../attachments';
-import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import { useBoolean } from '../hooks/useBoolean';
 import { useLocationContext } from '../hooks/useLocationContext';
 import { attachmentSet } from '../redux-actions';
@@ -161,7 +160,7 @@ const AttachMenu: React.FC = () => {
       } else if (kind === 'Alert') {
         setLoading();
         const labels = Object.fromEntries(new URLSearchParams(location.search));
-        consoleFetchJSON(ALERTS_ENDPOINT, 'get', getRequestInitWithAuthHeader())
+        consoleFetchJSON(ALERTS_ENDPOINT)
           .then((response) => {
             let alert;
             each(response?.data?.groups, (group) => {

--- a/src/components/Feedback.tsx
+++ b/src/components/Feedback.tsx
@@ -22,6 +22,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { toOLSAttachment } from '../attachments';
+import { getApiUrl } from '../config';
 import { ErrorType, getFetchErrorMessage } from '../error';
 import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import {
@@ -36,7 +37,7 @@ import CloseButton from './CloseButton';
 import CopyAction from './CopyAction';
 import ErrorBoundary from './ErrorBoundary';
 
-const USER_FEEDBACK_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/feedback';
+const USER_FEEDBACK_ENDPOINT = getApiUrl('/v1/feedback');
 
 const REQUEST_TIMEOUT = 5 * 60 * 1000;
 

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -40,7 +40,7 @@ import {
 import { toOLSAttachment } from '../attachments';
 import { getApiUrl } from '../config';
 import { getFetchErrorMessage } from '../error';
-import { AuthStatus, useAuth } from '../hooks/useAuth';
+import { AuthStatus, getRequestInitWithAuthHeader, useAuth } from '../hooks/useAuth';
 import { useBoolean } from '../hooks/useBoolean';
 import {
   attachmentDelete,
@@ -463,9 +463,9 @@ const GeneralPage: React.FC<GeneralPageProps> = ({ onClose, onCollapse, onExpand
         setStreamController(controller);
         const response = await consoleFetch(QUERY_ENDPOINT, {
           method: 'POST',
-          headers: {
+          headers: Object.assign({}, getRequestInitWithAuthHeader().headers, {
             'Content-Type': 'application/json',
-          },
+          }),
           body: JSON.stringify(requestJSON),
           signal: controller.signal,
         });

--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -38,6 +38,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { toOLSAttachment } from '../attachments';
+import { getApiUrl } from '../config';
 import { getFetchErrorMessage } from '../error';
 import { AuthStatus, useAuth } from '../hooks/useAuth';
 import { useBoolean } from '../hooks/useBoolean';
@@ -66,7 +67,7 @@ import ToolModal from './ResponseToolModal';
 
 import './general-page.css';
 
-const QUERY_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/streaming_query';
+const QUERY_ENDPOINT = getApiUrl('/v1/streaming_query');
 
 type QueryResponseStart = {
   event: 'start';

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 
+import { getApiUrl } from '../config';
 import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import { useBoolean } from '../hooks/useBoolean';
 import { useHideLightspeed } from '../hooks/useHideLightspeed';
@@ -17,8 +18,7 @@ import './popover.css';
 // TODO: Include this for now to work around bug where CSS is not pulled in by console plugin SDK
 import './pf-styles.css';
 
-const FEEDBACK_STATUS_ENDPOINT =
-  '/api/proxy/plugin/lightspeed-console-plugin/ols/v1/feedback/status';
+const FEEDBACK_STATUS_ENDPOINT = getApiUrl('/v1/feedback/status');
 const REQUEST_TIMEOUT = 5 * 60 * 1000;
 
 const Popover: React.FC = () => {

--- a/src/components/ReadinessAlert.tsx
+++ b/src/components/ReadinessAlert.tsx
@@ -3,9 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, Spinner } from '@patternfly/react-core';
 
+import { getApiUrl } from '../config';
 import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 
-const READINESS_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/readiness';
+const READINESS_ENDPOINT = getApiUrl('/readiness');
 const REQUEST_TIMEOUT = 5 * 60 * 1000;
 
 const ReadinessAlert: React.FC = () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,3 @@
+const API_BASE_URL = '/api/proxy/plugin/lightspeed-console-plugin/ols';
+
+export const getApiUrl = (path: string): string => `${API_BASE_URL}${path}`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
-const API_BASE_URL = '/api/proxy/plugin/lightspeed-console-plugin/ols';
+const DEFAULT_API_BASE_URL = '/api/proxy/plugin/lightspeed-console-plugin/ols';
 
-export const getApiUrl = (path: string): string => `${API_BASE_URL}${path}`;
+export const getApiUrl = (path: string): string => {
+  const base = (process.env.OLS_API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/+$/, '');
+  return `${base}${path}`;
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 
+import { getApiUrl } from '../config';
+
 export enum AuthStatus {
   Authorized = 'Authorized',
   AuthorizedError = 'AuthorizedError',
@@ -9,7 +11,7 @@ export enum AuthStatus {
   NotAuthorized = 'NotAuthorized',
 }
 
-const AUTHORIZATION_ENDPOINT = '/api/proxy/plugin/lightspeed-console-plugin/ols/authorized';
+const AUTHORIZATION_ENDPOINT = getApiUrl('/authorized');
 
 type AuthorizationResponse = {
   user_id: string;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,7 +20,7 @@ type AuthorizationResponse = {
 
 export const getRequestInitWithAuthHeader = (): RequestInit => {
   const init: RequestInit = {};
-  const bearerToken = process.env.REACT_BEARER_TOKEN;
+  const bearerToken = process.env.OLS_API_BEARER_TOKEN;
   if (bearerToken) {
     init.headers = { Authorization: `Bearer ${bearerToken}` };
   }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,7 +3,6 @@
 import { DefinePlugin, Configuration as WebpackConfiguration } from 'webpack';
 import * as path from 'path';
 import { ConsoleRemotePlugin } from '@openshift-console/dynamic-plugin-sdk-webpack';
-import * as dotenv from 'dotenv';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -12,8 +11,6 @@ interface Configuration extends WebpackConfiguration {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   devServer?: any;
 }
-
-dotenv.config();
 
 const config: Configuration = {
   mode: 'development',
@@ -78,7 +75,8 @@ const config: Configuration = {
   },
   plugins: [
     new DefinePlugin({
-      'process.env': JSON.stringify(process.env),
+      'process.env.OLS_API_BASE_URL': JSON.stringify(process.env.OLS_API_BASE_URL),
+      'process.env.OLS_API_BEARER_TOKEN': JSON.stringify(process.env.OLS_API_BEARER_TOKEN),
     }),
     new ConsoleRemotePlugin(),
     new CopyWebpackPlugin({


### PR DESCRIPTION
These changes only affect the development environment.
- Adds `OLS_API_BASE_URL` environment variable for easily changing the OLS API location for local development and testing
- Renames `REACT_BEARER_TOKEN` environment variable to `OLS_API_BEARER_TOKEN`
- Removes `dotenv` package