### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lightspeed-console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ USER 0
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
 RUN mkdir -p /licenses
 COPY --from=build /usr/src/app/LICENSE /licenses/LICENSE
-LABEL name="openshift-lightspeed/lightspeed-console" \
+LABEL name="openshift-lightspeed/lightspeed-console-plugin-rhel9" \
+      cpe="cpe:/a:redhat:openshift_lightspeed:1::el9" \
       com.redhat.component="openshift-lightspeed" \
       io.k8s.display-name="OpenShift Lightspeed Console" \
       summary="OpenShift Lightspeed Console provides OCP console plugin for OpenShift Lightspeed Service" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
