### PR TITLE
Downgrade @cypress/grep to v4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "webpack-cli": "^6.0.1"
       },
       "devDependencies": {
-        "@cypress/grep": "^5.0.0",
+        "@cypress/grep": "^4.1.1",
         "@cypress/webpack-preprocessor": "^7.0.1",
         "@types/node": "^24.6.2",
         "@types/react": "^17.0.88",
@@ -1940,9 +1940,9 @@
       }
     },
     "node_modules/@cypress/grep": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cypress/grep/-/grep-5.0.0.tgz",
-      "integrity": "sha512-VVKGfZdIrKZef7Q/lDOE7nWoVyoctbNp34moMDtPhQFPbo9bcV2WAeaHZijMrE/Hyl9gvorFL/BXsvwMuTxqJw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cypress/grep/-/grep-4.1.1.tgz",
+      "integrity": "sha512-KDM5kOJIQwdn7BGrmejCT34XCMLt8Bahd8h6RlRTYahs2gdc1wHq6XnrqlasF72GzHw0yAzCaH042hRkqu1gFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-cli": "^6.0.1"
   },
   "devDependencies": {
-    "@cypress/grep": "^5.0.0",
+    "@cypress/grep": "^4.1.1",
     "@cypress/webpack-preprocessor": "^7.0.1",
     "@types/node": "^24.6.2",
     "@types/react": "^17.0.88",


### PR DESCRIPTION
To avoid TypeScript error when running e2e tests with v5.0.0