### PR TITLE
Remove --pull=always option in start-console.sh script

### DIFF
--- a/start-console.sh
+++ b/start-console.sh
@@ -39,18 +39,18 @@ if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
         BRIDGE_PLUGINS="lightspeed-console-plugin=http://localhost:9001"
-        podman run --pull always --rm --network=host --env-file <(set | grep BRIDGE) \
+        podman run --rm --network=host --env-file <(set | grep BRIDGE) \
         --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/lightspeed-console-plugin/ols/", "endpoint": "http://localhost:'"${OLS_PORT}"'", "authorize": true}]}' \
         $CONSOLE_IMAGE
     else
         BRIDGE_PLUGINS="lightspeed-console-plugin=http://host.containers.internal:9001"
-        podman run --platform linux/amd64 --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) \
+        podman run --platform linux/amd64 --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) \
         --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/lightspeed-console-plugin/ols/", "endpoint": "http://host.containers.internal:'"${OLS_PORT}"'", "authorize": true}]}' \
         $CONSOLE_IMAGE
     fi
 else
     BRIDGE_PLUGINS="lightspeed-console-plugin=http://host.docker.internal:9001"
-    docker run --platform linux/amd64 --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) \
+    docker run --platform linux/amd64 --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) \
     --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/lightspeed-console-plugin/ols/", "endpoint": "http://host.docker.internal:'"${OLS_PORT}"'", "authorize": true}]}' \
     $CONSOLE_IMAGE
 fi


### PR DESCRIPTION
To reduce unnecessary downloads since we normally don't care for local development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed forced container image pulls during console startup, enabling faster startup times when using existing images across all supported container runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->