### PR TITLE
fix: correct label "name" to "openshift-lightspeed/lightspeed-console-plugin-419-rhel9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /tmp/nginx && \
     chgrp -R 0 /var/log/nginx /var/lib/nginx /usr/share/nginx/html /tmp/nginx && \
     chmod -R g=u /var/log/nginx /var/lib/nginx /usr/share/nginx/html /tmp/nginx
 
-LABEL name="openshift-lightspeed/lightspeed-console-plugin-rhel9" \
+LABEL name="openshift-lightspeed/lightspeed-console-plugin-419-rhel9" \
       cpe="cpe:/a:redhat:openshift_lightspeed:1::el9" \
       com.redhat.component="openshift-lightspeed" \
       io.k8s.display-name="OpenShift Lightspeed Console" \


### PR DESCRIPTION
This fixes the label check issue 
```
Error: Component 'lightspeed-console-4-19' name label ('openshift-lightspeed/lightspeed-console-plugin-rhel9') does not match expected name ('openshift-lightspeed/lightspeed-console-plugin-419-rhel9')
```