### PR TITLE
konflux: activate hermetic build, source image build for the 4.19 image

### DIFF
--- a/.tekton/lightspeed-console-4-19-pull-request.yaml
+++ b/.tekton/lightspeed-console-4-19-pull-request.yaml
@@ -30,8 +30,15 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-mxlarge/arm64
   - name: dockerfile
     value: Dockerfile
+  - name: prefetch-input
+    value: '[{"type": "npm", "path": "."}, {"type": "rpm", "path": "."}]'
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/lightspeed-console-4-19-push.yaml
+++ b/.tekton/lightspeed-console-4-19-push.yaml
@@ -27,8 +27,15 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-mxlarge/arm64
   - name: dockerfile
     value: Dockerfile
+  - name: prefetch-input
+    value: '[{"type": "npm", "path": "."}, {"type": "rpm", "path": "."}]'
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
This PR resolves 2 EC issues
```
  ✕ [Violation] hermetic_task.hermetic                                                                                                                              
      ImageRef:                                                                                                                                                      
  quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-4-19@sha256:ad61c9c7330a294997b83a8fe3632a1d8f1a2c31ac315251c00e1deb498ef629         
      Reason: Task 'buildah-remote-oci-ta' was not invoked with the hermetic parameter set                                                                           
      Title: Task called with hermetic param set                                                                                                                     
      Description: Verify the task in the PipelineRun attestation was invoked with the proper parameters to make the task execution                                  
      hermetic. To exclude this rule add "hermetic_task.hermetic" to the `exclude` section of the policy configuration.                                              
      Solution: Make sure the task has the input parameter 'HERMETIC' set to 'true'.                                                                                 
                                                                                                                                                                     
    ✕ [Violation] source_image.exists                                                                                                                                
      ImageRef:                                                                                                                                                      
  quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-4-19@sha256:ad61c9c7330a294997b83a8fe3632a1d8f1a2c31ac315251c00e1deb498ef629         
      Reason: No source image references found                                                                                                                       
      Title: Exists                                                                                                                                                  
      Description: Verify the source containerimage exists. To exclude this rule add "source_image.exists" to the `exclude` section                                 
      of the policy configuration.
```