### PR TITLE
Rennovate: Increase min age to 14 days for npm package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch"],
-      "minimumReleaseAge": "7 days",
+      "minimumReleaseAge": "14 days",
       "schedule": ["* * * * *"]
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update eligibility timing from 7 days to 14 days minimum release age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->