### PR TITLE
PF5: Use type="button" for non-submit buttons in modal forms

### DIFF
--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -177,7 +177,7 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
           <Button isDisabled={numEvents < 1} onClick={onSubmit} type="submit" variant="primary">
             {t('Attach')}
           </Button>
-          <Button onClick={onClose} type="submit" variant="link">
+          <Button onClick={onClose} type="button" variant="link">
             {t('Cancel')}
           </Button>
         </ActionGroup>

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -477,7 +477,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
           >
             {t('Attach')}
           </Button>
-          <Button onClick={onClose} type="submit" variant="link">
+          <Button onClick={onClose} type="button" variant="link">
             {t('Cancel')}
           </Button>
         </ActionGroup>

--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -175,7 +175,7 @@ const AttachmentModal: React.FC = () => {
         <Form>
           {isEditing ? (
             <ActionGroup>
-              <Button onClick={onSave} type="submit" variant="primary">
+              <Button onClick={onSave} type="button" variant="primary">
                 {t('Save')}
               </Button>
               <Button onClick={setNotEditing} variant="link">
@@ -187,7 +187,7 @@ const AttachmentModal: React.FC = () => {
               <SplitItem isFilled>
                 <ActionGroup>
                   {attachment?.isEditable && (
-                    <Button onClick={setEditing} type="submit" variant="primary">
+                    <Button onClick={setEditing} type="button" variant="primary">
                       {t('Edit')}
                     </Button>
                   )}


### PR DESCRIPTION
Cherry pick of https://github.com/openshift/lightspeed-console/pull/1797

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed modal dialog functionality in attachment-related operations throughout the application to eliminate unintended form submissions when users dismiss dialogs
  * Cancel buttons now reliably close dialogs without inadvertently processing or submitting data
  * Save and Edit buttons execute exclusively their intended functionality without triggering additional form submission side effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->