### PR TITLE
CodeRabbit: Don't use regex for release-4.19 branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,4 +2,4 @@ reviews:
   auto_review:
     base_branches:
       - 'pattern-fly-5'
-      - '^release-4\.19$'
+      - 'release-4.19'


### PR DESCRIPTION
It seems this was not working (no code reviews for the release-4.19 branch), so remove the regex like the pattern-fly-5 branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration for release branch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->