### PR TITLE
Hide compressing-history spinner when stream is cancelled

### DIFF
--- a/src/components/GeneralPage.tsx
+++ b/src/components/GeneralPage.tsx
@@ -299,7 +299,7 @@ const ChatHistoryEntry = React.memo(({ conversationID, entryIndex }: ChatHistory
                   {entry.error.moreInfo ? entry.error.moreInfo : entry.error.message}
                 </Alert>
               )}
-              {entry.historyCompression?.status === 'compressing' && (
+              {entry.historyCompression?.status === 'compressing' && !entry.isCancelled && (
                 <Alert
                   customIcon={<Spinner isInline size="md" />}
                   isInline


### PR DESCRIPTION
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the chat history compression status message would display incorrectly when an operation was cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->