### PR TITLE
Revert "CodeRabbit: Don't use regex for release-4.19 branch"

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,4 +2,4 @@ reviews:
   auto_review:
     base_branches:
       - 'pattern-fly-5'
-      - 'release-4.19'
+      - '^release-4\.19$'


### PR DESCRIPTION
This reverts commit 123a195d1c4e4b50d0510ae43fe0ccc48e1348df.

This change was unnecessary as actually the regex does work. The issue was actually that the config update had not been copied to the realease-4.19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to use stricter branch matching patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->