### PR TITLE
PF5: OLS-2901: Add unit tests using Node built-in test runner

### DIFF
--- a/.tekton/integration-tests/lightspeed-console-pre-commit-417.yaml
+++ b/.tekton/integration-tests/lightspeed-console-pre-commit-417.yaml
@@ -167,6 +167,8 @@ spec:
               echo "---------------------------------------------"
               npm run lint
               echo "---------------------------------------------"
+              npm run test:unit
+              echo "---------------------------------------------"
               npm run i18n
     - name: ols-e2e-tests
       description: Task to run tests from service repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,15 @@ All conversation state (chat history, attachments, etc.) is managed in Redux.
 
 ### Code structure
 
-- Frontend React code lives under `src/` (TypeScript/React)
+- Frontend React code lives in `src/` (TypeScript/React)
   - React components in `src/components/`
   - React hooks in `src/hooks/`
   - Redux code in `src/`
 - Put images and other assets in `src/assets/`
 - Modules and extensions exposed by the plugin are added to
   `console-extensions.json`
-- Test-related code lives under `tests/` and `cypress/`
+- End-to-end tests live in `tests/` and `cypress/`
+- Unit tests live in `unit-tests/`
 
 ### Coding style
 
@@ -94,12 +95,17 @@ All conversation state (chat history, attachments, etc.) is managed in Redux.
   - The `start-console.sh` script includes a proxy configuration that routes
     requests through the console, avoiding CORS issues
 
-### Tests (Cypress)
+### End-to-end tests (Cypress)
 
 - To run all tests: `npm run test-headless`
 - To run just some tests filtered by tag:
   `npm run test-headless -- --expose grepTags="@attach"`
 - See `tests/README.md` for full details and environment variables
+
+### Unit tests
+
+- Unit tests live in `unit-tests/` and use Node's built-in test runner
+- To run: `npm run test:unit`
 
 ### Do not commit
 
@@ -112,4 +118,5 @@ All conversation state (chat history, attachments, etc.) is managed in Redux.
 - Apply lint rules: `npm run lint-fix`
 - Update i18n strings: `npm run i18n`
 - Ensure build works: `npm run build`
+- Ensure unit tests pass: `npm run test:unit`
 - Ensure tests pass: `npm run test-headless`

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "start-console": "./start-console.sh",
     "i18n": "./i18n-scripts/build-i18n.sh && node ./i18n-scripts/set-english-defaults.js",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
-    "lint": "eslint ./*.{js,ts} ./src ./cypress ./tests && stylelint \"src/**/*.css\" --allow-empty-input",
-    "lint-fix": "eslint ./*.{js,ts} ./src ./cypress ./tests --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
+    "lint": "eslint ./*.{js,ts} ./src ./cypress ./tests ./unit-tests && stylelint \"src/**/*.css\" --allow-empty-input",
+    "lint-fix": "eslint ./*.{js,ts} ./src ./cypress ./tests ./unit-tests --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "test": "npx cypress open",
-    "test-headless": "npx cypress run --browser chrome"
+    "test-headless": "npx cypress run --browser chrome",
+    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node -r ts-node/register --test 'unit-tests/**/*.test.ts'"
   },
   "dependencies": {
     "@openshift-console/dynamic-plugin-sdk": "1.4.0",

--- a/unit-tests/attachments.test.ts
+++ b/unit-tests/attachments.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+
+import { AttachmentTypes, isAttachmentChanged, toOLSAttachment } from '../src/attachments';
+import { Attachment } from '../src/types';
+
+const makeAttachment = (overrides: Partial<Attachment> = {}): Attachment => ({
+  attachmentType: AttachmentTypes.YAML,
+  kind: 'Pod',
+  name: 'my-pod',
+  namespace: 'default',
+  value: 'apiVersion: v1',
+  ...overrides,
+});
+
+describe('isAttachmentChanged', () => {
+  it('returns false when originalValue is undefined', () => {
+    strictEqual(isAttachmentChanged(makeAttachment()), false);
+  });
+
+  it('returns false when originalValue equals value', () => {
+    const attachment = makeAttachment({ originalValue: 'apiVersion: v1' });
+    strictEqual(isAttachmentChanged(attachment), false);
+  });
+
+  it('returns true when originalValue differs from value', () => {
+    const attachment = makeAttachment({ originalValue: 'apiVersion: v2' });
+    strictEqual(isAttachmentChanged(attachment), true);
+  });
+});
+
+/* eslint-disable camelcase */
+describe('toOLSAttachment', () => {
+  it('maps YAML to api object with application/yaml', () => {
+    deepStrictEqual(toOLSAttachment(makeAttachment()), {
+      attachment_type: 'api object',
+      content: 'apiVersion: v1',
+      content_type: 'application/yaml',
+    });
+  });
+
+  it('maps YAMLFiltered to api object with application/yaml', () => {
+    const attachment = makeAttachment({ attachmentType: AttachmentTypes.YAMLFiltered });
+    deepStrictEqual(toOLSAttachment(attachment), {
+      attachment_type: 'api object',
+      content: 'apiVersion: v1',
+      content_type: 'application/yaml',
+    });
+  });
+
+  it('maps YAMLUpload to api object with application/yaml', () => {
+    const attachment = makeAttachment({ attachmentType: AttachmentTypes.YAMLUpload });
+    deepStrictEqual(toOLSAttachment(attachment), {
+      attachment_type: 'api object',
+      content: 'apiVersion: v1',
+      content_type: 'application/yaml',
+    });
+  });
+
+  it('maps Events to event with application/yaml', () => {
+    const attachment = makeAttachment({ attachmentType: AttachmentTypes.Events });
+    deepStrictEqual(toOLSAttachment(attachment), {
+      attachment_type: 'event',
+      content: 'apiVersion: v1',
+      content_type: 'application/yaml',
+    });
+  });
+
+  it('maps Log to log with text/plain', () => {
+    const attachment = makeAttachment({
+      attachmentType: AttachmentTypes.Log,
+      value: 'ERROR: something went wrong',
+    });
+    deepStrictEqual(toOLSAttachment(attachment), {
+      attachment_type: 'log',
+      content: 'ERROR: something went wrong',
+      content_type: 'text/plain',
+    });
+  });
+
+  it('passes through the attachment value as content', () => {
+    const attachment = makeAttachment({ value: 'kind: Deployment\nmetadata:\n  name: test' });
+    strictEqual(toOLSAttachment(attachment).content, 'kind: Deployment\nmetadata:\n  name: test');
+  });
+});
+/* eslint-enable camelcase */

--- a/unit-tests/error.test.ts
+++ b/unit-tests/error.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual } from 'node:assert';
+
+import { FetchError, getFetchErrorMessage } from '../src/error';
+
+// Stub for the i18next t() function that performs interpolation like the real one
+const t = ((s: string, opts?: Record<string, unknown>) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  opts ? s.replace(/\{\{(\w+)\}\}/g, (_, key) => String(opts[key] ?? '')) : s) as any;
+
+describe('getFetchErrorMessage', () => {
+  it('returns the detail string when detail is a string', () => {
+    const error: FetchError = { json: { detail: 'Something went wrong' } };
+    deepStrictEqual(getFetchErrorMessage(error, t), { message: 'Something went wrong' });
+  });
+
+  it('returns response and cause when detail is an object', () => {
+    const error: FetchError = {
+      json: { detail: { response: 'Model not available', cause: 'Provider timeout' } },
+    };
+    deepStrictEqual(getFetchErrorMessage(error, t), {
+      message: 'Model not available',
+      moreInfo: 'Provider timeout',
+    });
+  });
+
+  it('falls back to json.message when detail is missing', () => {
+    const error: FetchError = { json: { message: 'Bad request' } };
+    const result = getFetchErrorMessage(error, t);
+    deepStrictEqual(result, {
+      message:
+        'If this error persists, please contact an administrator. Error details: Bad request',
+    });
+  });
+
+  it('falls back to error.message when json.message is missing', () => {
+    const error: FetchError = { message: 'Network error' };
+    const result = getFetchErrorMessage(error, t);
+    deepStrictEqual(result, {
+      message:
+        'If this error persists, please contact an administrator. Error details: Network error',
+    });
+  });
+
+  it('falls back to response.statusText as last resort', () => {
+    const error: FetchError = { response: { statusText: 'Internal Server Error' } as Response };
+    const result = getFetchErrorMessage(error, t);
+    deepStrictEqual(result, {
+      message:
+        'If this error persists, please contact an administrator. Error details: Internal Server Error',
+    });
+  });
+
+  it('ignores detail object when cause is missing', () => {
+    const error: FetchError = { json: { detail: { response: 'partial' } as never } };
+    const result = getFetchErrorMessage(error, t);
+    deepStrictEqual(result, {
+      message: 'If this error persists, please contact an administrator. Error details: ',
+    });
+  });
+
+  it('ignores detail object when response is missing', () => {
+    const error: FetchError = { json: { detail: { cause: 'partial' } as never } };
+    const result = getFetchErrorMessage(error, t);
+    deepStrictEqual(result, {
+      message: 'If this error persists, please contact an administrator. Error details: ',
+    });
+  });
+});

--- a/unit-tests/redux-reducers.test.ts
+++ b/unit-tests/redux-reducers.test.ts
@@ -1,0 +1,327 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+
+import reducer, { OLSState } from '../src/redux-reducers';
+import { ActionType } from '../src/redux-actions';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const dispatch = (state: OLSState, type: ActionType, payload?: any) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reducer(state, { type, payload } as any);
+
+const initState = (): OLSState =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reducer(undefined as any, { type: '' } as any);
+
+describe('reducer initialization', () => {
+  it('returns default state when state is undefined', () => {
+    const state = initState();
+    strictEqual(ImmutableMap.isMap(state), true);
+    strictEqual(state.get('isOpen'), false);
+    strictEqual(state.get('query'), '');
+    strictEqual(state.get('conversationID'), null);
+    strictEqual(state.get('autoSubmit'), false);
+    strictEqual(state.get('hidePrompt'), false);
+    strictEqual(state.get('isUserFeedbackEnabled'), true);
+    strictEqual(state.get('isContextEventsLoading'), false);
+    strictEqual(state.get('codeBlock'), null);
+    strictEqual(state.get('openAttachment'), null);
+    strictEqual(ImmutableList.isList(state.get('chatHistory')), true);
+    strictEqual(state.get('chatHistory').size, 0);
+    strictEqual(ImmutableMap.isMap(state.get('attachments')), true);
+    strictEqual(state.get('attachments').size, 0);
+    deepStrictEqual(state.get('contextEvents'), []);
+  });
+});
+
+describe('reducer returns state unchanged for unknown action', () => {
+  it('returns the same state reference', () => {
+    const state = initState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const next = reducer(state, { type: 'nonexistent' } as any);
+    strictEqual(next, state);
+  });
+});
+
+describe('context events', () => {
+  it('AddContextEvent appends to empty list', () => {
+    const state = initState();
+    const event = { kind: 'Pod', message: 'Started' };
+    const next = dispatch(state, ActionType.AddContextEvent, { event });
+    deepStrictEqual(next.get('contextEvents'), [event]);
+  });
+
+  it('AddContextEvent appends to existing events', () => {
+    let state = initState();
+    const event1 = { kind: 'Pod', message: 'Started' };
+    const event2 = { kind: 'Pod', message: 'Pulled' };
+    state = dispatch(state, ActionType.AddContextEvent, { event: event1 });
+    state = dispatch(state, ActionType.AddContextEvent, { event: event2 });
+    deepStrictEqual(state.get('contextEvents'), [event1, event2]);
+  });
+
+  it('ClearContextEvents resets to empty array', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AddContextEvent, { event: { msg: 'test' } });
+    state = dispatch(state, ActionType.ClearContextEvents);
+    deepStrictEqual(state.get('contextEvents'), []);
+  });
+
+  it('SetIsContextEventsLoading sets the loading flag', () => {
+    const state = initState();
+    const next = dispatch(state, ActionType.SetIsContextEventsLoading, { isLoading: true });
+    strictEqual(next.get('isContextEventsLoading'), true);
+  });
+});
+
+describe('attachments', () => {
+  const attachment = {
+    attachmentType: 'YAML',
+    kind: 'Pod',
+    name: 'my-pod',
+    namespace: 'default',
+    ownerName: 'my-deploy',
+    value: 'apiVersion: v1',
+  };
+
+  it('AttachmentSet with explicit id', () => {
+    const state = initState();
+    const next = dispatch(state, ActionType.AttachmentSet, { ...attachment, id: 'custom-id' });
+    strictEqual(next.getIn(['attachments', 'custom-id']).kind, 'Pod');
+  });
+
+  it('AttachmentSet generates id from type, kind, name, and ownerName', () => {
+    const state = initState();
+    const next = dispatch(state, ActionType.AttachmentSet, attachment);
+    const expectedID = 'YAML_Pod_my-pod_my-deploy';
+    strictEqual(next.getIn(['attachments', expectedID]).kind, 'Pod');
+  });
+
+  it('AttachmentSet uses NO-OWNER when ownerName is undefined', () => {
+    const state = initState();
+    const noOwner = {
+      attachmentType: 'YAML',
+      kind: 'Pod',
+      name: 'my-pod',
+      namespace: 'default',
+      value: 'apiVersion: v1',
+    };
+    const next = dispatch(state, ActionType.AttachmentSet, noOwner);
+    const expectedID = 'YAML_Pod_my-pod_NO-OWNER';
+    strictEqual(next.getIn(['attachments', expectedID]).kind, 'Pod');
+  });
+
+  it('AttachmentDelete removes an attachment by id', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, { ...attachment, id: 'del-me' });
+    strictEqual(state.get('attachments').size, 1);
+    state = dispatch(state, ActionType.AttachmentDelete, { id: 'del-me' });
+    strictEqual(state.get('attachments').size, 0);
+  });
+
+  it('AttachmentsClear removes all attachments', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, { ...attachment, id: 'a' });
+    state = dispatch(state, ActionType.AttachmentSet, { ...attachment, id: 'b' });
+    strictEqual(state.get('attachments').size, 2);
+    state = dispatch(state, ActionType.AttachmentsClear);
+    strictEqual(state.get('attachments').size, 0);
+  });
+});
+
+describe('chat history', () => {
+  const aiEntry = {
+    id: 'msg-1',
+    who: 'ai',
+    text: 'Hello',
+    isStreaming: true,
+    isCancelled: false,
+    isTruncated: false,
+  };
+
+  it('ChatHistoryPush adds an entry', () => {
+    const state = initState();
+    const next = dispatch(state, ActionType.ChatHistoryPush, { entry: aiEntry });
+    strictEqual(next.get('chatHistory').size, 1);
+    strictEqual(next.get('chatHistory').get(0).get('id'), 'msg-1');
+  });
+
+  it('ChatHistoryPush preserves existing entries', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.ChatHistoryPush, { entry: aiEntry });
+    state = dispatch(state, ActionType.ChatHistoryPush, {
+      entry: { ...aiEntry, id: 'msg-2', text: 'World' },
+    });
+    strictEqual(state.get('chatHistory').size, 2);
+    strictEqual(state.get('chatHistory').get(0).get('id'), 'msg-1');
+    strictEqual(state.get('chatHistory').get(1).get('id'), 'msg-2');
+  });
+
+  it('ChatHistoryClear removes all entries', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.ChatHistoryPush, { entry: aiEntry });
+    state = dispatch(state, ActionType.ChatHistoryClear);
+    strictEqual(state.get('chatHistory').size, 0);
+  });
+
+  it('ChatHistoryUpdateByID merges fields into the matching entry', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.ChatHistoryPush, { entry: aiEntry });
+    state = dispatch(state, ActionType.ChatHistoryUpdateByID, {
+      id: 'msg-1',
+      entry: { isStreaming: false, text: 'Hello, updated' },
+    });
+    const updated = state.get('chatHistory').get(0);
+    strictEqual(updated.get('isStreaming'), false);
+    strictEqual(updated.get('text'), 'Hello, updated');
+    strictEqual(updated.get('id'), 'msg-1');
+  });
+
+  it('ChatHistoryUpdateTool merges tool data into the matching entry', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.ChatHistoryPush, { entry: aiEntry });
+    state = dispatch(state, ActionType.ChatHistoryUpdateTool, {
+      id: 'msg-1',
+      toolID: 'tool-1',
+      tool: { name: 'search', status: 'success', content: 'result' },
+    });
+    const tool = state.getIn(['chatHistory', 0, 'tools', 'tool-1']);
+    strictEqual(tool.get('name'), 'search');
+    strictEqual(tool.get('status'), 'success');
+  });
+});
+
+describe('popover open/close', () => {
+  it('OpenOLS sets isOpen to true', () => {
+    const state = initState();
+    strictEqual(dispatch(state, ActionType.OpenOLS).get('isOpen'), true);
+  });
+
+  it('CloseOLS sets isOpen to false and hidePrompt to false', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.OpenOLS);
+    state = dispatch(state, ActionType.SetHidePrompt, { hidePrompt: true });
+    state = dispatch(state, ActionType.CloseOLS);
+    strictEqual(state.get('isOpen'), false);
+    strictEqual(state.get('hidePrompt'), false);
+  });
+});
+
+describe('simple setters', () => {
+  it('SetQuery', () => {
+    const state = initState();
+    strictEqual(dispatch(state, ActionType.SetQuery, { query: 'hello' }).get('query'), 'hello');
+  });
+
+  it('SetConversationID', () => {
+    const state = initState();
+    const next = dispatch(state, ActionType.SetConversationID, { id: 'conv-123' });
+    strictEqual(next.get('conversationID'), 'conv-123');
+  });
+
+  it('SetAutoSubmit', () => {
+    const state = initState();
+    strictEqual(
+      dispatch(state, ActionType.SetAutoSubmit, { autoSubmit: true }).get('autoSubmit'),
+      true,
+    );
+  });
+
+  it('SetHidePrompt', () => {
+    const state = initState();
+    strictEqual(
+      dispatch(state, ActionType.SetHidePrompt, { hidePrompt: true }).get('hidePrompt'),
+      true,
+    );
+  });
+
+  it('ImportCodeBlock', () => {
+    const state = initState();
+    const code = { id: 'cb-1', value: 'console.log("hi")' };
+    strictEqual(dispatch(state, ActionType.ImportCodeBlock, { code }).get('codeBlock'), code);
+  });
+});
+
+describe('open attachment', () => {
+  it('OpenAttachmentSet stores the attachment', () => {
+    const state = initState();
+    const attachment = { kind: 'Pod', name: 'test' };
+    const next = dispatch(state, ActionType.OpenAttachmentSet, { attachment });
+    deepStrictEqual(next.get('openAttachment'), attachment);
+  });
+
+  it('OpenAttachmentClear resets to null', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.OpenAttachmentSet, { attachment: { kind: 'Pod' } });
+    state = dispatch(state, ActionType.OpenAttachmentClear);
+    strictEqual(state.get('openAttachment'), null);
+  });
+});
+
+describe('open tool', () => {
+  it('OpenToolSet stores chatEntryIndex and id', () => {
+    const state = initState();
+    const next = dispatch(state, ActionType.OpenToolSet, { chatEntryIndex: 2, id: 'tool-5' });
+    strictEqual(next.getIn(['openTool', 'chatEntryIndex']), 2);
+    strictEqual(next.getIn(['openTool', 'id']), 'tool-5');
+  });
+
+  it('OpenToolClear resets both fields to null', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.OpenToolSet, { chatEntryIndex: 2, id: 'tool-5' });
+    state = dispatch(state, ActionType.OpenToolClear);
+    strictEqual(state.getIn(['openTool', 'chatEntryIndex']), null);
+    strictEqual(state.getIn(['openTool', 'id']), null);
+  });
+});
+
+describe('user feedback', () => {
+  const pushAIEntry = (state: OLSState) =>
+    dispatch(state, ActionType.ChatHistoryPush, {
+      entry: {
+        id: 'msg-1',
+        who: 'ai',
+        text: 'Hi',
+        isStreaming: false,
+        isCancelled: false,
+        isTruncated: false,
+      },
+    });
+
+  it('UserFeedbackOpen sets isOpen on the entry', () => {
+    let state = pushAIEntry(initState());
+    state = dispatch(state, ActionType.UserFeedbackOpen, { entryIndex: 0 });
+    strictEqual(state.getIn(['chatHistory', 0, 'userFeedback', 'isOpen']), true);
+  });
+
+  it('UserFeedbackClose sets isOpen to false', () => {
+    let state = pushAIEntry(initState());
+    state = dispatch(state, ActionType.UserFeedbackOpen, { entryIndex: 0 });
+    state = dispatch(state, ActionType.UserFeedbackClose, { entryIndex: 0 });
+    strictEqual(state.getIn(['chatHistory', 0, 'userFeedback', 'isOpen']), false);
+  });
+
+  it('UserFeedbackSetSentiment stores sentiment value', () => {
+    let state = pushAIEntry(initState());
+    state = dispatch(state, ActionType.UserFeedbackSetSentiment, { entryIndex: 0, sentiment: 1 });
+    strictEqual(state.getIn(['chatHistory', 0, 'userFeedback', 'sentiment']), 1);
+  });
+
+  it('UserFeedbackSetText stores feedback text', () => {
+    let state = pushAIEntry(initState());
+    state = dispatch(state, ActionType.UserFeedbackSetText, {
+      entryIndex: 0,
+      text: 'Great answer',
+    });
+    strictEqual(state.getIn(['chatHistory', 0, 'userFeedback', 'text']), 'Great answer');
+  });
+
+  it('UserFeedbackDisable disables feedback globally', () => {
+    const state = initState();
+    strictEqual(
+      dispatch(state, ActionType.UserFeedbackDisable).get('isUserFeedbackEnabled'),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Cherry pick of https://github.com/openshift/lightspeed-console/pull/1792

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unit testing framework integrated using Node's built-in test runner.
  * New `npm run test:unit` command added for running unit tests.

* **Documentation**
  * Test structure documentation updated with unit testing guidelines and execution instructions.

* **Tests**
  * Comprehensive unit test coverage added for core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->