### PR TITLE
OLS-2786: Add note on current web console page context when submitting prompts

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -138,7 +138,7 @@ Cypress.Commands.add(
     cy.intercept('POST', getApiUrl('/v1/streaming_query'), (request) => {
       expect(request.body.media_type).to.equal('application/json');
       expect(request.body.conversation_id).to.equal(conversationId);
-      expect(request.body.query).to.equal(query);
+      expect(request.body.query).to.include(query);
 
       expect(request.body.attachments).to.have.lengthOf(attachments.length);
       attachments.forEach((a, i) => {
@@ -168,7 +168,7 @@ Cypress.Commands.add(
   'interceptQueryWithError',
   (alias: string, query: string, errorMessage: string) => {
     cy.intercept('POST', getApiUrl('/v1/streaming_query'), (request) => {
-      expect(request.body.query).to.equal(query);
+      expect(request.body.query).to.include(query);
       const responseBody = MOCK_STREAMED_RESPONSE_WITH_ERROR_BODY.replace(
         'MOCK_ERROR_MESSAGE',
         errorMessage,

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -31,6 +31,7 @@ import {
   TaskIcon,
   WrenchIcon,
 } from '@patternfly/react-icons';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import { AttachmentTypes, toOLSAttachment } from '../attachments';
 import { getApiUrl } from '../config';
@@ -38,6 +39,7 @@ import { getFetchErrorMessage } from '../error';
 import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import { useBoolean } from '../hooks/useBoolean';
 import { useLocationContext } from '../hooks/useLocationContext';
+import { buildPageContext } from '../pageContext';
 import {
   attachmentDelete,
   attachmentsClear,
@@ -134,7 +136,13 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
+  const location = useLocation();
   const [kind, name, namespace] = useLocationContext();
+
+  const pageContext = React.useMemo(
+    () => buildPageContext(kind, name, namespace),
+    [kind, name, namespace],
+  );
 
   const k8sContext = useK8sWatchResource<K8sResourceKind>(
     kind && kind !== 'Alert' && name ? { isList: false, kind, name, namespace } : null,
@@ -468,6 +476,7 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
       context,
       dispatch,
       kind,
+      location.search,
       name,
       namespace,
       openEventsModal,
@@ -534,7 +543,7 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
       // eslint-disable-next-line camelcase
       media_type: 'application/json',
       mode: isTroubleshooting ? 'troubleshooting' : 'ask',
-      query,
+      query: pageContext ? `Context: ${pageContext}\n\n${query}` : query,
     };
 
     const streamResponse = async () => {
@@ -718,6 +727,7 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
     hidePrompt,
     isStreaming,
     isTroubleshooting,
+    pageContext,
     query,
     scrollIntoView,
     t,

--- a/src/hooks/useLocationContext.ts
+++ b/src/hooks/useLocationContext.ts
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { useK8sModels } from '@openshift-console/dynamic-plugin-sdk';
 
+import { resolveModelKey } from '../pageContext';
+
 export const useLocationContext = () => {
   const [kind, setKind] = React.useState<string>();
   const [name, setName] = React.useState<string>();
@@ -25,47 +27,25 @@ export const useLocationContext = () => {
 
         urlMatches = path.match(new RegExp(`/k8s/ns/(${ns})/(${resourceKey})/(${resourceName})`));
         if (urlMatches) {
-          const key = urlMatches[2];
-
-          if (models[key]) {
-            setKind(key);
+          const modelKey = resolveModelKey(urlMatches[2], models);
+          // Exclude Secret details pages to avoid accidentally including secrets with prompt
+          if (modelKey && models[modelKey]?.kind !== 'Secret') {
+            setKind(modelKey);
             setName(urlMatches[3]);
             setNamespace(urlMatches[1]);
             return;
-          }
-
-          const modelKey = Object.keys(models).find((k) => models[k].plural === key);
-          if (modelKey) {
-            const model = models[modelKey];
-            if (model && model.kind !== 'Secret') {
-              setKind(model.kind);
-              setName(urlMatches[3]);
-              setNamespace(urlMatches[1]);
-              return;
-            }
           }
         }
 
         urlMatches = path.match(new RegExp(`/k8s/cluster/(${resourceKey})/(${resourceName})`));
         if (urlMatches) {
-          const key = urlMatches[1];
-
-          if (models[key]) {
-            setKind(key);
+          const modelKey = resolveModelKey(urlMatches[1], models);
+          // Exclude Secret details pages to avoid accidentally including secrets with prompt
+          if (modelKey && models[modelKey]?.kind !== 'Secret') {
+            setKind(modelKey);
             setName(urlMatches[2]);
             setNamespace(undefined);
             return;
-          }
-
-          const modelKey = Object.keys(models).find((k) => models[k].plural === key);
-          if (modelKey) {
-            const model = models[modelKey];
-            if (model && model.kind !== 'Secret') {
-              setKind(model.kind);
-              setName(urlMatches[2]);
-              setNamespace(undefined);
-              return;
-            }
           }
         }
 
@@ -133,6 +113,42 @@ export const useLocationContext = () => {
           setName(urlMatches[3]);
           setNamespace(urlMatches[2]);
           return;
+        }
+
+        // Namespaced list page: /k8s/ns/{namespace}/{resourceKey}
+        urlMatches = path.match(new RegExp(`/k8s/ns/(${ns})/(${resourceKey})/?$`));
+        if (urlMatches) {
+          const modelKey = resolveModelKey(urlMatches[2], models);
+          if (modelKey) {
+            setKind(modelKey);
+            setName(undefined);
+            setNamespace(urlMatches[1]);
+            return;
+          }
+        }
+
+        // All-namespaces list page: /k8s/all-namespaces/{resourceKey}
+        urlMatches = path.match(new RegExp(`/k8s/all-namespaces/(${resourceKey})/?$`));
+        if (urlMatches) {
+          const modelKey = resolveModelKey(urlMatches[1], models);
+          if (modelKey) {
+            setKind(modelKey);
+            setName(undefined);
+            setNamespace(undefined);
+            return;
+          }
+        }
+
+        // Cluster-scoped list page: /k8s/cluster/{resourceKey}
+        urlMatches = path.match(new RegExp(`/k8s/cluster/(${resourceKey})/?$`));
+        if (urlMatches) {
+          const modelKey = resolveModelKey(urlMatches[1], models);
+          if (modelKey) {
+            setKind(modelKey);
+            setName(undefined);
+            setNamespace(undefined);
+            return;
+          }
         }
       }
 

--- a/src/pageContext.ts
+++ b/src/pageContext.ts
@@ -1,0 +1,40 @@
+// Resolve a URL resource key to a k8s model key. The URL segment can be a direct model key
+// (e.g. "Pod"), a plural (e.g. "pods"), or a group~version~kind reference where the model
+// is stored under just the kind (e.g. "core~v1~Pod" → "Pod").
+export const resolveModelKey = (
+  urlKey: string,
+  models: Record<string, { kind?: string; plural?: string }>,
+): string | undefined => {
+  if (models[urlKey]) {
+    return urlKey;
+  }
+  const byPlural = Object.keys(models).find((k) => models[k].plural === urlKey);
+  if (byPlural) {
+    return byPlural;
+  }
+  if (urlKey.includes('~')) {
+    const kindPart = urlKey.split('~').pop();
+    if (kindPart && models[kindPart]) {
+      return kindPart;
+    }
+  }
+  return undefined;
+};
+
+export const buildPageContext = (
+  kind: string | undefined,
+  name: string | undefined,
+  namespace: string | undefined,
+): string | undefined => {
+  if (!kind) {
+    return undefined;
+  }
+
+  if (name) {
+    const ns = namespace ? ` in namespace "${namespace}"` : '';
+    return `The user is viewing the details of ${kind} "${name}"${ns} in the OpenShift web console.`;
+  }
+
+  const ns = namespace ? ` in namespace "${namespace}"` : ' across all namespaces';
+  return `The user is viewing a list of ${kind} resources${ns} in the OpenShift web console.`;
+};

--- a/unit-tests/pageContext.test.ts
+++ b/unit-tests/pageContext.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import { strictEqual } from 'node:assert';
+
+import { buildPageContext, resolveModelKey } from '../src/pageContext';
+
+describe('buildPageContext', () => {
+  it('returns undefined when kind is undefined', () => {
+    strictEqual(buildPageContext(undefined, undefined, undefined), undefined);
+  });
+
+  it('returns detail page context with namespace', () => {
+    strictEqual(
+      buildPageContext('Deployment', 'nginx', 'default'),
+      'The user is viewing the details of Deployment "nginx" in namespace "default" in the OpenShift web console.',
+    );
+  });
+
+  it('returns detail page context without namespace (cluster-scoped)', () => {
+    strictEqual(
+      buildPageContext('Node', 'worker-1', undefined),
+      'The user is viewing the details of Node "worker-1" in the OpenShift web console.',
+    );
+  });
+
+  it('preserves group~version~kind format in detail context', () => {
+    strictEqual(
+      buildPageContext('kubevirt.io~v1~VirtualMachine', 'my-vm', 'default'),
+      'The user is viewing the details of kubevirt.io~v1~VirtualMachine "my-vm" in namespace "default" in the OpenShift web console.',
+    );
+  });
+
+  it('returns list page context with namespace', () => {
+    strictEqual(
+      buildPageContext('Deployment', undefined, 'default'),
+      'The user is viewing a list of Deployment resources in namespace "default" in the OpenShift web console.',
+    );
+  });
+
+  it('returns list page context across all namespaces', () => {
+    strictEqual(
+      buildPageContext('Pod', undefined, undefined),
+      'The user is viewing a list of Pod resources across all namespaces in the OpenShift web console.',
+    );
+  });
+});
+
+const models = {
+  Pod: { kind: 'Pod', plural: 'pods' },
+  Deployment: { kind: 'Deployment', plural: 'deployments' },
+  Node: { kind: 'Node', plural: 'nodes' },
+  Secret: { kind: 'Secret', plural: 'secrets' },
+  'kubevirt.io~v1~VirtualMachine': { kind: 'VirtualMachine', plural: 'virtualmachines' },
+};
+
+describe('resolveModelKey', () => {
+  it('resolves a direct model key', () => {
+    strictEqual(resolveModelKey('Pod', models), 'Pod');
+  });
+
+  it('resolves a CRD model key with group~version~kind', () => {
+    strictEqual(
+      resolveModelKey('kubevirt.io~v1~VirtualMachine', models),
+      'kubevirt.io~v1~VirtualMachine',
+    );
+  });
+
+  it('resolves a plural name to the model key', () => {
+    strictEqual(resolveModelKey('pods', models), 'Pod');
+  });
+
+  it('resolves a plural CRD name to the model key', () => {
+    strictEqual(resolveModelKey('virtualmachines', models), 'kubevirt.io~v1~VirtualMachine');
+  });
+
+  it('resolves core~v1~Kind by extracting the kind portion', () => {
+    strictEqual(resolveModelKey('core~v1~Pod', models), 'Pod');
+  });
+
+  it('resolves core~v1~Deployment by extracting the kind portion', () => {
+    strictEqual(resolveModelKey('core~v1~Deployment', models), 'Deployment');
+  });
+
+  it('returns undefined for an unknown key', () => {
+    strictEqual(resolveModelKey('UnknownResource', models), undefined);
+  });
+
+  it('returns undefined for an unknown group~version~kind', () => {
+    strictEqual(resolveModelKey('fake.io~v1~Nothing', models), undefined);
+  });
+
+  it('returns undefined for an empty string', () => {
+    strictEqual(resolveModelKey('', models), undefined);
+  });
+});


### PR DESCRIPTION
Automatically include a short description of the user's current console page (resource details page details or list page details) in the prompt.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queries now include contextual information from the current page for more relevant results.
  * Routing-aware page context improves behavior on resource detail and list pages.

* **Bug Fixes / Improvements**
  * Better handling of list and cluster-scoped pages, with clearer context and namespace behavior.

* **Tests**
  * Added unit tests for page-context and model-resolution.
  * Updated e2e test assertions to be more flexible for streaming query requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->