### PR TITLE
Add base-branch staleness check and auto npm install to rebase skill

### DIFF
--- a/.cursor/skills/rebase/SKILL.md
+++ b/.cursor/skills/rebase/SKILL.md
@@ -8,8 +8,7 @@ description: >-
 
 # Rebase
 
-Rebase the current branch onto its base branch. This skill assumes the local
-repo is already up to date (no fetch/pull needed).
+Rebase the current branch onto its base branch.
 
 ## Step 1 — Determine the base branch
 
@@ -27,13 +26,38 @@ between the merge-base and HEAD). If counts are tied, prefer `main`.
 
 Tell the user which base branch was detected before proceeding.
 
-## Step 2 — Rebase
+## Step 2 — Check if base branch is up to date
+
+Run `git fetch upstream <base-branch>` to update the remote tracking ref (this
+is read-only and does not change any local branches), then compare:
 
 ```sh
+git fetch upstream <base-branch>
+git rev-list --count <base-branch>..upstream/<base-branch>
+```
+
+If the count is **0**, the local base branch is up to date — skip ahead to
+**Step 3**.
+
+If the count is **greater than 0**, tell the user how many commits their local
+base branch is behind the remote and **ask whether they want to pull**. Do NOT
+pull without the user's consent.
+
+- If the user says **yes**, run `git checkout <base-branch> && git merge --ff-only upstream/<base-branch> && git checkout -` then continue to Step 3.
+- If the user says **no** (or to skip), continue to Step 3 using the local
+  base branch as-is.
+
+## Step 3 — Rebase
+
+Save the current commit hash before rebasing so it can be used for comparison
+later:
+
+```sh
+pre_rebase_head=$(git rev-parse HEAD)
 git rebase <base-branch>
 ```
 
-If the rebase completes cleanly, skip to **Step 3**.
+If the rebase completes cleanly, skip to **Step 4**.
 
 ### Resolving conflicts
 
@@ -49,19 +73,25 @@ When conflicts occur, repeat this loop until the rebase finishes:
 4. Continue: `git rebase --continue`.
 5. If new conflicts appear, go back to substep 1.
 
-## Step 3 — Fix lint, i18n, and build
+## Step 4 — Fix lint, i18n, and build
 
 After the rebase succeeds, run the following commands **in order**, fixing any
 errors before moving on:
 
 1. `npm run lint-fix` — fix lint/formatting issues automatically.
 2. `npm run i18n` — regenerate locale files.
-3. `npm run build` — ensure the project compiles.
+3. Before building, check whether `npm install` needs to be run. Compare the
+   current `package-lock.json` against the saved pre-rebase commit:
+   ```sh
+   git diff "$pre_rebase_head" -- package-lock.json
+   ```
+   If there are changes, run `npm install` before continuing.
+4. `npm run build` — ensure the project compiles.
 
 If any step produces errors that `lint-fix` did not auto-resolve, fix them
 manually and re-run the failing command until it passes.
 
-## Step 4 — Report
+## Step 5 — Report
 
 Summarize what happened:
 


### PR DESCRIPTION
The rebase skill now checks whether the local base branch is behind its upstream remote tracking branch before rebasing, prompting the user to pull if needed. It also detects package-lock.json changes after rebase and runs npm install automatically before building.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebase workflow now checks if your local base branch is behind the remote and prompts you to update before rebasing.
  * Records the pre-rebase state to improve recovery and verification.
  * After a successful rebase, dependencies are automatically installed only when relevant changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->