### PR TITLE
OLS-2925: Fix re-selecting an attachment overwriting user edits

### DIFF
--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -1,6 +1,7 @@
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import { ActionType, OLSAction } from './redux-actions';
+import { isAttachmentChanged } from './attachments';
 import { Attachment } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -60,7 +61,14 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
       const id =
         action.payload.id ??
         `${action.payload.attachmentType}_${action.payload.kind}_${action.payload.name}_${action.payload.ownerName ?? 'NO-OWNER'}`;
-      return state.setIn(['attachments', id], action.payload);
+      const existing: Attachment | undefined = state.getIn(['attachments', id]);
+      // Preserve user edits when re-selecting the same resource from the attach menu (no
+      // originalValue). Explicit saves from the editor pass originalValue and bypass this guard.
+      const newAttachment =
+        existing && isAttachmentChanged(existing) && action.payload.originalValue === undefined
+          ? { ...existing, originalValue: action.payload.value }
+          : action.payload;
+      return state.setIn(['attachments', id], newAttachment);
     }
 
     case ActionType.ChatHistoryClear:

--- a/unit-tests/redux-reducers.test.ts
+++ b/unit-tests/redux-reducers.test.ts
@@ -158,7 +158,7 @@ describe('attachments', () => {
     strictEqual(state.getIn(['attachments', alertId]).originalValue, 'original yaml');
   });
 
-  it('AttachmentSet with explicit id updates in place on revert (no duplicate)', () => {
+  it('AttachmentSet with explicit id preserves edits on re-select (no duplicate)', () => {
     const alertId = 'YAML_Alert_alertname=HighMemory,severity=warning';
     const alertAttachment = {
       attachmentType: 'YAML',
@@ -188,8 +188,73 @@ describe('attachments', () => {
     });
     strictEqual(state.get('attachments').size, 1);
     strictEqual(state.get('attachments').has(alertId), true);
-    strictEqual(state.getIn(['attachments', alertId]).value, 'original yaml');
-    strictEqual(state.getIn(['attachments', alertId]).originalValue, undefined);
+    strictEqual(state.getIn(['attachments', alertId]).value, 'edited yaml');
+    strictEqual(state.getIn(['attachments', alertId]).originalValue, 'original yaml');
+  });
+
+  it('AttachmentSet overwrites unedited attachment with same id', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, { ...attachment, id: 'a' });
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'updated yaml',
+    });
+    strictEqual(state.getIn(['attachments', 'a']).value, 'updated yaml');
+    strictEqual(state.getIn(['attachments', 'a']).originalValue, undefined);
+  });
+
+  it('AttachmentSet preserves user edits when re-selecting same attachment', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'edited yaml',
+      originalValue: 'apiVersion: v1',
+    });
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'fresh yaml from server',
+    });
+    strictEqual(state.getIn(['attachments', 'a']).value, 'edited yaml');
+    strictEqual(state.getIn(['attachments', 'a']).originalValue, 'fresh yaml from server');
+  });
+
+  it('AttachmentSet allows explicit save with originalValue on edited attachment', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'first edit',
+      originalValue: 'apiVersion: v1',
+    });
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'second edit',
+      originalValue: 'apiVersion: v1',
+    });
+    strictEqual(state.getIn(['attachments', 'a']).value, 'second edit');
+    strictEqual(state.getIn(['attachments', 'a']).originalValue, 'apiVersion: v1');
+  });
+
+  it('AttachmentSet respects empty-string originalValue as explicit', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'first edit',
+      originalValue: '',
+    });
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'second edit',
+      originalValue: '',
+    });
+    strictEqual(state.getIn(['attachments', 'a']).value, 'second edit');
+    strictEqual(state.getIn(['attachments', 'a']).originalValue, '');
   });
 });
 


### PR DESCRIPTION
The AttachmentSet reducer now preserves user edits when the same resource is re-attached from the menu without an originalValue. Explicit saves from the editor (which pass originalValue) bypass this guard and work as before.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve prior user-edited attachment values when the same attachment is re-selected; user edits are no longer unintentionally overwritten. Explicit original values (including empty string) are now respected and updated appropriately.

* **Tests**
  * Added unit tests covering attachment re-selection scenarios: unedited overwrite, preserving user edits, explicit original-value handling, and empty-string original-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->