### PR TITLE
OLS-2927: Fix editing alert attachment creating a duplicate instead of updating

### DIFF
--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -130,6 +130,7 @@ const AttachmentModal: React.FC = () => {
           attachment.namespace,
           editorValue,
           originalValue,
+          attachment.id,
         ),
       );
     }
@@ -149,6 +150,7 @@ const AttachmentModal: React.FC = () => {
         attachment.namespace,
         value,
         undefined,
+        attachment.id,
       ),
     );
     setEditorValue(value);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ declare global {
 
 export type Attachment = {
   attachmentType: string;
+  id?: string;
   isEditable?: boolean;
   kind: string;
   name: string;

--- a/unit-tests/redux-reducers.test.ts
+++ b/unit-tests/redux-reducers.test.ts
@@ -129,6 +129,68 @@ describe('attachments', () => {
     state = dispatch(state, ActionType.AttachmentsClear);
     strictEqual(state.get('attachments').size, 0);
   });
+
+  it('AttachmentSet with explicit id updates in place on save (no duplicate)', () => {
+    const alertId = 'YAML_Alert_alertname=HighMemory,severity=warning';
+    const alertAttachment = {
+      attachmentType: 'YAML',
+      kind: 'Alert',
+      name: 'HighMemory',
+      namespace: '',
+      value: 'original yaml',
+      id: alertId,
+    };
+
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, alertAttachment);
+    strictEqual(state.get('attachments').size, 1);
+    strictEqual(state.getIn(['attachments', alertId]).value, 'original yaml');
+
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...alertAttachment,
+      value: 'edited yaml',
+      originalValue: 'original yaml',
+      id: alertId,
+    });
+    strictEqual(state.get('attachments').size, 1);
+    strictEqual(state.get('attachments').has(alertId), true);
+    strictEqual(state.getIn(['attachments', alertId]).value, 'edited yaml');
+    strictEqual(state.getIn(['attachments', alertId]).originalValue, 'original yaml');
+  });
+
+  it('AttachmentSet with explicit id updates in place on revert (no duplicate)', () => {
+    const alertId = 'YAML_Alert_alertname=HighMemory,severity=warning';
+    const alertAttachment = {
+      attachmentType: 'YAML',
+      kind: 'Alert',
+      name: 'HighMemory',
+      namespace: '',
+      value: 'original yaml',
+      id: alertId,
+    };
+
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, alertAttachment);
+
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...alertAttachment,
+      value: 'edited yaml',
+      originalValue: 'original yaml',
+      id: alertId,
+    });
+    strictEqual(state.get('attachments').size, 1);
+
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...alertAttachment,
+      value: 'original yaml',
+      originalValue: undefined,
+      id: alertId,
+    });
+    strictEqual(state.get('attachments').size, 1);
+    strictEqual(state.get('attachments').has(alertId), true);
+    strictEqual(state.getIn(['attachments', alertId]).value, 'original yaml');
+    strictEqual(state.getIn(['attachments', alertId]).originalValue, undefined);
+  });
 });
 
 describe('chat history', () => {


### PR DESCRIPTION
Alert attachments use a custom Redux map key based on sorted labels, but AttachmentModal's save and revert did not pass the attachment id back to attachmentSet, causing the reducer to generate a different default key and store the edit as a second entry.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachments now maintain stable identity during save and revert, preventing duplicate entries and ensuring in-place updates.
* **Tests**
  * Added tests verifying consistent attachment behavior when an explicit identifier is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->