### PR TITLE
PF5: Hide events slider when only one event exists

### DIFF
--- a/locales/en/plugin__lightspeed-console-plugin.json
+++ b/locales/en/plugin__lightspeed-console-plugin.json
@@ -84,6 +84,7 @@
   "No pods found for {{kind}} {{name}}": "No pods found for {{kind}} {{name}}",
   "Not authenticated": "Not authenticated",
   "Not authorized": "Not authorized",
+  "Only one event available for this resource.": "Only one event available for this resource.",
   "OpenShift Lightspeed": "OpenShift Lightspeed",
   "OpenShift Lightspeed authentication failed. Contact your system administrator for more information.": "OpenShift Lightspeed authentication failed. Contact your system administrator for more information.",
   "OpenShift Lightspeed chat history": "OpenShift Lightspeed chat history",

--- a/src/components/AttachEventsModal.tsx
+++ b/src/components/AttachEventsModal.tsx
@@ -130,9 +130,11 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={t('Configure events attachment')}>
       <Text>
-        {t(
-          'You can specify the most recent number of events from this resource to include as an attachment for detailed troubleshooting and analysis.',
-        )}
+        {events.length === 1
+          ? t('Only one event available for this resource.')
+          : t(
+              'You can specify the most recent number of events from this resource to include as an attachment for detailed troubleshooting and analysis.',
+            )}
       </Text>
       <Form>
         {isLoading && <Spinner size="md" />}
@@ -143,15 +145,17 @@ const AttachEventsModal: React.FC<Props> = ({ isOpen, kind, name, namespace, onC
             </HelperText>
           ) : (
             <>
-              <FormGroup label={t('Most recent {{numEvents}} events', { numEvents })}>
-                <Slider
-                  max={events.length}
-                  min={1}
-                  onChange={onInputNumEventsChange}
-                  showTicks={events.length <= 40}
-                  value={numEvents}
-                />
-              </FormGroup>
+              {events.length > 1 && (
+                <FormGroup label={t('Most recent {{numEvents}} events', { numEvents })}>
+                  <Slider
+                    max={events.length}
+                    min={1}
+                    onChange={onInputNumEventsChange}
+                    showTicks={events.length <= 40}
+                    value={numEvents}
+                  />
+                </FormGroup>
+              )}
               <CodeBlock
                 actions={
                   <>


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/lightspeed-console/pull/1838

The slider is unnecessary when there is a single event since there is only one possible value. It reappears automatically when more events arrive via the WebSocket.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the event selection modal to display context-specific messaging and simplified controls when only one event is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->