### PR TITLE
Pin dependency versions to enforce minimumReleaseAge on lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "schedule": ["* 6 * * *"],
   "timezone": "UTC",
-  "rangeStrategy": "bump",
+  "rangeStrategy": "pin",
   "lockFileMaintenance": {
     "enabled": false
   },


### PR DESCRIPTION
With rangeStrategy "bump", package.json gets caret ranges (e.g. ^15.13.1) that pass minimumReleaseAge, but npm resolves the lockfile to the latest compatible version which can be newer. Switching to "pin" ensures exact versions so the lockfile always matches what Renovate validated.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine how version constraint updates are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->