### PR TITLE
OLS-2925: Fix revert not clearing edit icon from attachment label

### DIFF
--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -149,7 +149,7 @@ const AttachmentModal: React.FC = () => {
         attachment.ownerName,
         attachment.namespace,
         value,
-        undefined,
+        value,
         attachment.id,
       ),
     );

--- a/unit-tests/redux-reducers.test.ts
+++ b/unit-tests/redux-reducers.test.ts
@@ -239,6 +239,27 @@ describe('attachments', () => {
     strictEqual(state.getIn(['attachments', 'a']).originalValue, 'apiVersion: v1');
   });
 
+  it('AttachmentSet revert clears changed state when originalValue equals value', () => {
+    let state = initState();
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'edited yaml',
+      originalValue: 'apiVersion: v1',
+    });
+    strictEqual(state.getIn(['attachments', 'a']).value, 'edited yaml');
+    strictEqual(state.getIn(['attachments', 'a']).originalValue, 'apiVersion: v1');
+
+    state = dispatch(state, ActionType.AttachmentSet, {
+      ...attachment,
+      id: 'a',
+      value: 'apiVersion: v1',
+      originalValue: 'apiVersion: v1',
+    });
+    strictEqual(state.getIn(['attachments', 'a']).value, 'apiVersion: v1');
+    strictEqual(state.getIn(['attachments', 'a']).originalValue, 'apiVersion: v1');
+  });
+
   it('AttachmentSet respects empty-string originalValue as explicit', () => {
     let state = initState();
     state = dispatch(state, ActionType.AttachmentSet, {


### PR DESCRIPTION
The onRevert handler passed undefined as originalValue to attachmentSet, which triggered the re-attach guard added in eb78619 and silently preserved the edited value in the attachments map. Pass the reverted value as originalValue instead so the guard is bypassed and isAttachmentChanged returns false.

Introduced by https://github.com/openshift/lightspeed-console/pull/1839

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment revert functionality to properly maintain state consistency when reverting changes.

* **Tests**
  * Added comprehensive unit test for attachment state synchronization during revert operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->