### PR TITLE
Tests: Replace all console-image flags with the PR image

### DIFF
--- a/tests/tests/lightspeed-install.cy.ts
+++ b/tests/tests/lightspeed-install.cy.ts
@@ -173,8 +173,8 @@ describe('OLS UI', () => {
               const args =
                 csv.spec.install.spec.deployments[0].spec.template.spec.containers[0].args.map(
                   (arg) =>
-                    arg.startsWith('--console-image=')
-                      ? `--console-image=${Cypress.env('CONSOLE_IMAGE')}`
+                    arg.startsWith('--console-image')
+                      ? arg.replace(/=.*/, `=${Cypress.env('CONSOLE_IMAGE')}`)
                       : arg,
                 );
 


### PR DESCRIPTION
When running tests in CI, replace all console images with the image for the PR being tested. This ensures the PR image is always used regardless of the OCP version being used.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for container configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->