### PR TITLE
PF5: Tests: Replace all console-image flags with the PR image

### DIFF
--- a/tests/tests/lightspeed-install.cy.ts
+++ b/tests/tests/lightspeed-install.cy.ts
@@ -173,8 +173,8 @@ describe('OLS UI', () => {
               const args =
                 csv.spec.install.spec.deployments[0].spec.template.spec.containers[0].args.map(
                   (arg) =>
-                    arg.startsWith('--console-image-pf5=')
-                      ? `--console-image-pf5=${Cypress.env('CONSOLE_IMAGE')}`
+                    arg.startsWith('--console-image')
+                      ? arg.replace(/=.*/, `=${Cypress.env('CONSOLE_IMAGE')}`)
                       : arg,
                 );
 


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/lightspeed-console/pull/1868

When running tests in CI, replace all console images with the image for the PR being tested. This ensures the PR image is always used regardless of the OCP version being used.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined console image argument handling in test suite to more accurately target and update configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->