### PR TITLE
OLS-1555: PF5: Add Cypress tests for HITL tool approval flow

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -42,6 +42,8 @@ declare global {
         query: string,
         errorMessage: string,
       ): Chainable<Element>;
+      interceptQueryWithApproval(alias: string, query: string): Chainable<Element>;
+      interceptToolApproval(alias: string, approved: boolean): Chainable<Element>;
     }
   }
 }
@@ -191,6 +193,37 @@ Cypress.Commands.add(
     }).as(alias);
   },
 );
+
+/* eslint-disable camelcase */
+const MOCK_STREAMED_RESPONSE_WITH_APPROVAL_BODY = `data: {"event": "start", "data": {"conversation_id": "5f424596-a4f9-4a3a-932b-46a768de3e7c"}}
+
+data: {"event": "token", "data": {"id": 0, "token": "Mock"}}
+
+data: {"event": "token", "data": {"id": 1, "token": " response"}}
+
+data: {"event": "tool_call", "data": {"id": "tool-123", "name": "mock_tool", "args": {"namespace": "default"}}}
+
+data: {"event": "approval_required", "data": {"approval_id": "abc", "tool_name": "mock_tool", "tool_description": "This action will list pods in the cluster.", "tool_args": {"namespace": "default"}}}
+
+data: {"event": "end", "data": {"referenced_documents": [], "truncated": false}}
+`;
+/* eslint-enable camelcase */
+
+Cypress.Commands.add('interceptQueryWithApproval', (alias: string, query: string) => {
+  cy.intercept('POST', getApiUrl('/v1/streaming_query'), (request) => {
+    expect(request.body.media_type).to.equal('application/json');
+    expect(request.body.query).to.include(query);
+    request.reply({ body: MOCK_STREAMED_RESPONSE_WITH_APPROVAL_BODY, delay: 500 });
+  }).as(alias);
+});
+
+Cypress.Commands.add('interceptToolApproval', (alias: string, approved: boolean) => {
+  cy.intercept('POST', getApiUrl('/v1/tool-approvals/decision'), (request) => {
+    expect(request.body.approval_id).to.equal('abc');
+    expect(request.body.approved).to.equal(approved);
+    request.reply({ statusCode: 200, body: {} });
+  }).as(alias);
+});
 
 const USER_FEEDBACK_MOCK_RESPONSE = { body: { message: 'Feedback received' } };
 

--- a/tests/tests/lightspeed-install.cy.ts
+++ b/tests/tests/lightspeed-install.cy.ts
@@ -35,6 +35,8 @@ const userFeedbackInput = `${userFeedback} textarea`;
 const userFeedbackSubmit = `${userFeedback} button.pf-m-primary`;
 const modal = '.ols-plugin__modal';
 const tooltip = '.pf-v5-c-tooltip';
+const toolApprovalCard = `${popover} .ols-plugin__tool-call`;
+const toolLabel = `${popover} .pf-v5-c-label`;
 
 const podNamePrefix = 'console';
 
@@ -418,6 +420,65 @@ spec:
         .should('exist')
         .should('contain', MOCK_ERROR_MESSAGE);
       cy.get(aiChatEntry).find('.ols-plugin__references').should('contain', 'ABC');
+    });
+  });
+
+  describe('Tool approval (HITL)', { tags: ['@hitl'] }, () => {
+    it('Test approval card is shown and tool can be approved', () => {
+      cy.visit('/search/all-namespaces');
+      cy.get('h1').contains('Search').should('exist');
+      cy.get(mainButton).click();
+
+      cy.interceptQueryWithApproval('queryWithApproval', PROMPT_SUBMITTED);
+      cy.interceptToolApproval('approvalStub', true);
+      cy.get(promptInput).type(`${PROMPT_SUBMITTED}{enter}`);
+      cy.wait('@queryWithApproval');
+
+      cy.get(toolApprovalCard).should('exist');
+      cy.get(toolApprovalCard).should('contain', 'Review required');
+      cy.get(toolApprovalCard).should('contain', 'This action will list pods in the cluster.');
+      cy.get(toolApprovalCard).find('button').contains('Approve').should('exist');
+      cy.get(toolApprovalCard).find('button').contains('Reject').should('exist');
+
+      cy.get(toolApprovalCard).contains('View action details').click();
+      cy.get(toolApprovalCard).should('contain', 'mock_tool');
+      cy.get(toolApprovalCard).should('contain', 'namespace');
+
+      cy.get(toolApprovalCard).find('button').contains('Approve').click();
+      cy.wait('@approvalStub');
+      cy.get(toolApprovalCard).should('not.exist');
+      cy.get(toolLabel).should('contain', 'mock_tool');
+
+      cy.get(toolLabel).contains('mock_tool').click();
+      cy.get(modal).should('contain', 'Tool output');
+      cy.get(modal).should('contain', 'mock_tool');
+      cy.get(modal).should('contain', 'Status');
+      cy.get(modal).should('contain', 'pending');
+      cy.get(modal).should('not.contain', 'Tool call rejected');
+      cy.get(modal).find('button[title="Close"]').click();
+    });
+
+    it('Test tool can be rejected', () => {
+      cy.visit('/search/all-namespaces');
+      cy.get('h1').contains('Search').should('exist');
+      cy.get(mainButton).click();
+
+      cy.interceptQueryWithApproval('queryWithApproval', PROMPT_SUBMITTED);
+      cy.interceptToolApproval('denialStub', false);
+      cy.get(promptInput).type(`${PROMPT_SUBMITTED}{enter}`);
+      cy.wait('@queryWithApproval');
+
+      cy.get(toolApprovalCard).should('exist');
+      cy.get(toolApprovalCard).find('button').contains('Reject').click();
+      cy.wait('@denialStub');
+      cy.get(toolApprovalCard).should('not.exist');
+      cy.get(toolLabel).should('contain', 'mock_tool');
+      cy.get(toolLabel).contains('mock_tool').click();
+      cy.get(modal).should('contain', 'Tool call rejected');
+      cy.get(modal).should('contain', 'mock_tool');
+      cy.get(modal).should('not.contain', 'Status');
+      cy.get(modal).should('not.contain', 'Content');
+      cy.get(modal).find('button[title="Close"]').click();
     });
   });
 


### PR DESCRIPTION
Manual back port of https://github.com/openshift/lightspeed-console/pull/1909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added custom testing commands for query and tool approval workflows
  * Expanded test coverage with new test cases validating approval and rejection flows, including UI updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->