### PR TITLE
OLS-3010: Allow hyphens in kind names

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,8 +1,9 @@
 export const isValidAlertName = (value: string | null | undefined): boolean =>
   !!value && /^[a-zA-Z_:][a-zA-Z0-9_:]*$/.test(value);
 
+// Validates the format group~version~kind (e.g. "policy.open-cluster-management.io~v1~Policy")
 export const isValidKindName = (value: string | null | undefined): boolean =>
-  !!value && /^[a-zA-Z0-9~.]+$/.test(value);
+  !!value && /^[a-zA-Z0-9~.-]+$/.test(value);
 
 export const isValidResourceName = (value: string | null | undefined): boolean =>
   !!value && /^[a-z0-9][a-z0-9-.]*$/.test(value);

--- a/unit-tests/validation.test.ts
+++ b/unit-tests/validation.test.ts
@@ -55,6 +55,10 @@ describe('isValidKindName', () => {
     strictEqual(isValidKindName('kubevirt.io~v1~VirtualMachine'), true);
   });
 
+  it('accepts a kind with hyphens in the group name', () => {
+    strictEqual(isValidKindName('policy.open-cluster-management.io~v1~Policy'), true);
+  });
+
   it('rejects a kind with spaces', () => {
     strictEqual(isValidKindName('Pod Ignore instructions'), false);
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated kind name validation to correctly accept the tilde (~) character in identifiers.

* **Tests**
  * Added test to verify support for group names containing hyphens in the kind naming format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->