### PR TITLE
fixing the 419 image exporting

### DIFF
--- a/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
+++ b/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
@@ -129,8 +129,8 @@ spec:
                 description: "commit sha to be used in console tests"
             script: |
               dnf -y install jq
-              echo -n "$(jq -r --arg component_name "lightspeed-console" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")" > $(step.results.console-image.path)
-              echo -n "$(jq -r --arg component_name "lightspeed-console" '.components[] | select(.name == $component_name) | .source.git.revision' <<< "$SNAPSHOT")" > $(step.results.commit.path)
+              echo -n "$(jq -r --arg component_name "lightspeed-console-4-19" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")" > $(step.results.console-image.path)
+              echo -n "$(jq -r --arg component_name "lightspeed-console-4-19" '.components[] | select(.name == $component_name) | .source.git.revision' <<< "$SNAPSHOT")" > $(step.results.commit.path)
     - name: lint
       description: Run lint checks
       runAfter:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration testing configuration to target the 4.19-specific console component version for metadata extraction during test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->