### PR TITLE
PF5: Bump webpack-dev-server from 5.2.3 to 5.2.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "prettier": "^3.8.1",
         "stylelint": "^17.6.0",
         "stylelint-config-standard": "^40.0.0",
-        "webpack-dev-server": "^5.2.3"
+        "webpack-dev-server": "5.2.4"
       },
       "engines": {
         "node": ">=22.22.2"
@@ -14470,9 +14470,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": "^3.8.1",
     "stylelint": "^17.6.0",
     "stylelint-config-standard": "^40.0.0",
-    "webpack-dev-server": "^5.2.3"
+    "webpack-dev-server": "5.2.4"
   },
   "overrides": {
     "webpack": "5.106.2"


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/lightspeed-console/pull/1959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->