### PR TITLE
4.19: Add .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=14

--- a/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
+++ b/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
@@ -276,6 +276,8 @@ spec:
               echo "---------------------------------------------"
               NODE_OPTIONS=--max-old-space-size=4096 npm ci --omit=optional --no-fund
               echo "---------------------------------------------"
+              npx cypress install
+              echo "---------------------------------------------"
               export CYPRESS_LOGIN_PASSWORD=$(cat ${PASSWORD_PATH})
               set +e
               NO_COLOR=1 npx cypress run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ All conversation state (chat history, attachments, etc.) is managed in Redux.
 ### Running
 
 - Dependencies are installed by running `npm install`
+  - Then run `npx cypress install` to download the Cypress binary (required
+    because `.npmrc` sets `ignore-scripts=true`)
 - To run the project locally:
   - Run `npm run start` in one terminal
     - Starts the dev server for the plugin on port 9001

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,14 @@ cluster and then run a series of Cypress e2e tests against the UI.
 All required dependencies are defined in `package.json`. Run `npm install` to
 install the dependencies in the `node_modules` folder.
 
+Because `.npmrc` sets `ignore-scripts=true` for security, Cypress's postinstall
+script does not run automatically. You must explicitly install the Cypress binary
+before running tests:
+
+```bash
+npx cypress install
+```
+
 ## Export necessary variables
 
 Test behavior can be customized by setting environment variables.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * npm configuration updated to set ignore-scripts=true and min-release-age=14.
* **Tests**
  * CI end-to-end workflow now runs an explicit "npx cypress install" step before executing tests.
* **Documentation**
  * Local setup and test README updated to instruct running "npx cypress install" prior to running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->