### PR TITLE
PF5: OLS-3127: Enable TypeScript noImplicitAny option & fix types as necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
         "@patternfly/react-code-editor": "5.4.18",
         "@patternfly/react-core": "5.4.14",
         "@patternfly/react-icons": "5.4.2",
+        "@types/js-yaml": "4.0.9",
+        "@types/lodash": "4.17.24",
+        "@types/murmurhash-js": "1.0.7",
+        "@types/react-modal": "3.16.3",
+        "@types/react-redux": "7.1.34",
         "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^7.1.4",
         "dompurify": "3.4.2",
@@ -1927,6 +1932,18 @@
         "@types/unist": "^2"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -1942,6 +1959,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1949,9 +1972,10 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
@@ -1977,6 +2001,12 @@
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+    },
+    "node_modules/@types/murmurhash-js": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/murmurhash-js/-/murmurhash-js-1.0.7.tgz",
+      "integrity": "sha512-XM6078Du3jaEJVwpxmPZsJQDMzWabjY4ILQQvW4VPBzTULd+Fjs2Z54s+OrLzDRxgs6J09YyDISnZDlltYAchw==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
@@ -2020,6 +2050,27 @@
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/retry": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
     "ts-loader": "^9.5.7",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
+    "@types/js-yaml": "4.0.9",
+    "@types/lodash": "4.17.24",
+    "@types/murmurhash-js": "1.0.7",
+    "@types/react-modal": "3.16.3",
+    "@types/react-redux": "7.1.34",
     "webpack": "5.106.2",
     "webpack-cli": "^7.0.2"
   },

--- a/src/components/AttachLogModal.tsx
+++ b/src/components/AttachLogModal.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import {
   consoleFetchText,
   K8sResourceKind,
+  Selector,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -257,9 +258,9 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
     isCronJob ? { isList: true, kind: 'Job', namespace } : null,
   );
 
-  let selector;
+  let selector: Selector | undefined;
   if (kind === 'Job') {
-    selector = { 'job-name': name };
+    selector = { matchLabels: { 'job-name': name } };
   } else if (isCronJob) {
     const ownedJobNames = (jobs || [])
       .filter((job) =>
@@ -281,7 +282,7 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
       selector = undefined;
     }
   } else if (kind === 'VirtualMachine' || kind === 'VirtualMachineInstance') {
-    selector = { 'vm.kubevirt.io/name': name };
+    selector = { matchLabels: { 'vm.kubevirt.io/name': name } };
   } else if (scaleTarget && scaleTargetLoaded && !scaleTargetError) {
     selector = scaleTarget.spec?.selector;
   } else {
@@ -297,7 +298,8 @@ const AttachLogModal: React.FC<AttachLogModalProps> = ({ isOpen, onClose, resour
   const changePod = (newPod: K8sResourceKind) => {
     if (newPod) {
       setPod(newPod);
-      const newContainers = newPod.spec?.containers?.map((c) => c.name).sort() ?? [];
+      const newContainers =
+        newPod.spec?.containers?.map((c: { name: string }) => c.name).sort() ?? [];
       setContainers(newContainers);
       setContainer(newContainers[0]);
     }

--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { BlueInfoCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import { CodeEditor, EditorDidMount, Language } from '@patternfly/react-code-editor';
 import {
   ActionGroup,
   Button,
@@ -49,10 +49,10 @@ type EditorProps = {
 const Editor: React.FC<EditorProps> = ({ onChange }) => {
   const attachment: Attachment = useSelector((s: State) => s.plugins?.ols?.get('openAttachment'));
 
-  const onEditorDidMount = (_editor, monaco) => {
+  const onEditorDidMount: EditorDidMount = (_editor, monaco) => {
     // Work around crash when CodeEditor attempts to call this nonexistent function
     // TODO: Figure out why this is happening
-    monaco.editor.onDidChangeMarkers = () => {};
+    (monaco.editor as unknown as { onDidChangeMarkers: () => void }).onDidChangeMarkers = () => {};
   };
 
   const [isDarkTheme] = useIsDarkTheme();

--- a/src/components/AttachmentsSizeAlert.tsx
+++ b/src/components/AttachmentsSizeAlert.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { Alert } from '@patternfly/react-core';
 
 import { State } from '../redux-reducers';
+import { Attachment } from '../types';
 
 const MAX_CHARS = 1000000;
 
@@ -12,7 +13,9 @@ const AttachmentsSizeAlert: React.FC = () => {
 
   const attachments = useSelector((s: State) => s.plugins?.ols?.get('attachments'));
 
-  const totalChars = attachments.valueSeq().reduce((sum, a) => sum + a.value.length, 0);
+  const totalChars = attachments
+    .valueSeq()
+    .reduce((sum: number, a: Attachment) => sum + a.value.length, 0);
 
   if (totalChars <= MAX_CHARS) {
     return null;

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -8,6 +8,10 @@ import {
   consoleFetch,
   consoleFetchJSON,
   K8sResourceKind,
+  PrometheusAlert,
+  PrometheusRule,
+  PrometheusRulesResponse,
+  Silence,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -58,6 +62,7 @@ import {
   setQuery,
 } from '../redux-actions';
 import { State } from '../redux-reducers';
+import { Attachment } from '../types';
 import AttachEventsModal from './AttachEventsModal';
 import AttachLogModal from './AttachLogModal';
 import ResourceIcon from './ResourceIcon';
@@ -141,8 +146,8 @@ const FileUploadSelectOption: React.FC<FileUploadSelectOptionProps> = ({ setErro
       reader.onload = (event) => {
         try {
           const yaml = event.target?.result as string;
-          const content = loadYAML(yaml);
-          if (typeof content !== 'object') {
+          const content = loadYAML(yaml) as K8sResourceKind | null;
+          if (typeof content !== 'object' || content === null) {
             setError(t('Uploaded file is not valid YAML'));
             return;
           }
@@ -217,8 +222,8 @@ const AttachMenu: React.FC = () => {
         setLoading();
         const labels = Object.fromEntries(new URLSearchParams(location.search));
         consoleFetchJSON(ALERTS_ENDPOINT, 'get', getRequestInitWithAuthHeader())
-          .then((response) => {
-            let alert;
+          .then((response: PrometheusRulesResponse) => {
+            let alert: PrometheusAlert | undefined;
             each(response?.data?.groups, (group) => {
               each(group.rules, (rule) => {
                 alert = rule.alerts?.find((a) => isMatch(labels, a.labels));
@@ -268,7 +273,7 @@ const AttachMenu: React.FC = () => {
       } else if (attachmentType === AttachmentTypes.YAML && kind === 'Silence') {
         setLoading();
         consoleFetchJSON(`${SILENCE_ENDPOINT}/${name}`, 'get', getRequestInitWithAuthHeader())
-          .then((silence) => {
+          .then((silence: Silence) => {
             try {
               const silenceName =
                 silence.matchers
@@ -296,8 +301,8 @@ const AttachMenu: React.FC = () => {
         const ruleLabels = Object.fromEntries(new URLSearchParams(location.search));
         const rulesEndpoint = ruleLabels.cluster ? ALERTS_THANOS_ENDPOINT : ALERTS_ENDPOINT;
         consoleFetchJSON(rulesEndpoint, 'get', getRequestInitWithAuthHeader())
-          .then((response) => {
-            let matchedRule;
+          .then((response: PrometheusRulesResponse) => {
+            let matchedRule: PrometheusRule | undefined;
             each(response?.data?.groups, (group) => {
               const found = group.rules?.find(
                 (rule) => rule.type === 'alerting' && alertingRuleID(group, rule) === name,
@@ -610,7 +615,7 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
 
       dispatch(
         chatHistoryPush({
-          attachments: attachments.map((a) => omit(a, 'originalValue')),
+          attachments: attachments.map((a: Attachment) => omit(a, 'originalValue')),
           hidden: hidePrompt,
           text: query,
           who: 'user',

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -6,7 +6,7 @@ import Popover from '../components/Popover';
 
 const POPOVER_ID = 'plugin__lightspeed-console-plugin__POPOVER_ID';
 
-const usePopover = () => {
+const usePopover = (): null => {
   const [isLaunched, , setLaunched] = useBoolean(false);
 
   const launchModal = useModal();
@@ -21,7 +21,7 @@ const usePopover = () => {
     }
   }, [isLaunched, launchModal, setLaunched]);
 
-  return [];
+  return null;
 };
 
 export default usePopover;

--- a/src/redux-reducers.ts
+++ b/src/redux-reducers.ts
@@ -76,14 +76,14 @@ const reducer = (state: OLSState, action: OLSAction): OLSState => {
     case ActionType.ChatHistoryUpdateByID: {
       const index = state
         .get('chatHistory')
-        .findIndex((entry) => entry.get('id') === action.payload.id);
+        .findIndex((entry: ImmutableMap<string, unknown>) => entry.get('id') === action.payload.id);
       return state.mergeIn(['chatHistory', index], action.payload.entry);
     }
 
     case ActionType.ChatHistoryUpdateTool: {
       const index = state
         .get('chatHistory')
-        .findIndex((entry) => entry.get('id') === action.payload.id);
+        .findIndex((entry: ImmutableMap<string, unknown>) => entry.get('id') === action.payload.id);
       return state.mergeIn(
         ['chatHistory', index, 'tools', action.payload.toolID],
         action.payload.tool,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -14,7 +14,7 @@ export const alertingRuleID = (
     rule.query,
     ..._map(rule.labels, (v, k) => `${v}=${k}`),
   ].join(',');
-  return String(murmur3(key, 'monitoring-salt'));
+  return String(murmur3(key));
 };
 
 export const isValidAlertName = (value: string | null | undefined): boolean =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "jsx": "react",
     "allowJs": true,
     "strict": true,
-    "noImplicitAny": false,
     "strictNullChecks": false,
     "noUnusedLocals": true,
     "sourceMap": false,


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/lightspeed-console/pull/1971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added missing TypeScript type definitions and tightened compiler settings to enforce stricter typing.
  * Improved type annotations across UI components and hooks for more robust behavior.

* **Bug Fixes**
  * Adjusted alerting rule ID generation, which changes produced IDs for the same inputs (may affect existing references).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->