### PR TITLE
Renovate: Ignore react-router updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "matchPackageNames": ["react", "react-dom", "react-i18next", "react-redux"],
+      "matchPackageNames": ["react", "react-dom", "react-i18next", "react-redux", "react-router"],
       "enabled": false
     },
     {


### PR DESCRIPTION
The react-router version needs to match the version expected by the web console dynamic plugin SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated dependency management configuration to include `react-router` in automated update rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->