### PR TITLE
4.19: Replace shell-interpolated execSync with safe JS polling loop

### DIFF
--- a/tests/support/global-setup.ts
+++ b/tests/support/global-setup.ts
@@ -198,10 +198,16 @@ spec:
     const existingConfig = JSON.parse(configCheck);
     if (existingConfig.metadata.deletionTimestamp) {
       console.log('OLSConfig is being deleted. Waiting for deletion...');
-      execSync(
-        `timeout 180 bash -c 'until ! oc get ${OLS_CONFIG_KIND} ${OLS_CONFIG_NAME} --kubeconfig ${KUBECONFIG} 2>/dev/null; do echo "Waiting for deletion..."; sleep 5; done'`,
-        { encoding: 'utf-8', timeout: 4 * MINUTE },
-      );
+      const deadline = Date.now() + 3 * MINUTE;
+      while (Date.now() < deadline) {
+        try {
+          oc(['get', OLS_CONFIG_KIND, OLS_CONFIG_NAME]);
+        } catch {
+          break;
+        }
+        console.log('Waiting for deletion...');
+        execSync('sleep 5');
+      }
       configExists = false;
     } else {
       console.log('OLSConfig already exists. Using existing config.');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the resource cleanup wait logic in test setup, now polls periodically with a 3-minute timeout instead of a single timeout check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->