### PR TITLE
OLS-2926 - adding artifact exporting step and logs finalizer

### DIFF
--- a/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
+++ b/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
@@ -357,3 +357,23 @@ spec:
                   value: main
                 - name: pathInRepo
                   value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
+  finally:
+    - name: export-logs-for-retention
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/export-logs/0.1/export-logs-to-quay.yaml
+      params:
+        - name: pipeline-run-name
+          value: $(context.pipelineRun.name)
+        - name: namespace
+          value: $(context.pipelineRun.namespace)
+        - name: quay-repo
+          value: "quay.io/openshift-lightspeed/ols-console-artifacts"
+        - name: artifact-credentials-secret
+          value: ols-konflux-artifacts-bot

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -1,8 +1,10 @@
 import { test as base, expect, type Page } from '@playwright/test';
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const API_BASE_URL = '/api/proxy/plugin/lightspeed-console-plugin/ols';
-const getApiUrl = (path: string): string => `${API_BASE_URL}${path}`;
+const getApiUrl = (apiPath: string): string => `${API_BASE_URL}${apiPath}`;
 
 export const CONVERSATION_ID = '5f424596-a4f9-4a3a-932b-46a768de3e7c';
 
@@ -69,6 +71,101 @@ export const oc = (args: string[]): string =>
     encoding: 'utf-8',
     timeout: 180_000,
   });
+
+const ARTIFACTS_DIR = './gui_test_screenshots/artifacts';
+const OLS_NAMESPACE = 'openshift-lightspeed';
+
+const CLUSTER_RESOURCES = [
+  'pods',
+  'services',
+  'deployments',
+  'replicasets',
+  'routes',
+  'rolebindings',
+  'serviceaccounts',
+  'olsconfig',
+  'clusterserviceversion',
+  'installplan',
+  'configmap',
+];
+
+function safeOc(args: string[]): string | null {
+  try {
+    return oc(args);
+  } catch (e: unknown) {
+    // eslint-disable-next-line no-console
+    console.error(`oc ${args.slice(0, 3).join(' ')} failed: ${e}`);
+    return null;
+  }
+}
+
+export function gatherClusterArtifacts(): void {
+  const clusterDir = path.join(ARTIFACTS_DIR, 'cluster');
+  const podLogsDir = path.join(clusterDir, 'podlogs');
+  fs.mkdirSync(podLogsDir, { recursive: true });
+
+  for (const resource of CLUSTER_RESOURCES) {
+    const output = safeOc(['get', resource, '-n', OLS_NAMESPACE, '-o', 'yaml']);
+    if (output) {
+      fs.writeFileSync(path.join(clusterDir, `${resource}.yaml`), output);
+    }
+  }
+
+  const podsJson = safeOc(['get', 'pods', '-n', OLS_NAMESPACE, '-o', 'json']);
+  if (podsJson) {
+    try {
+      const pods = JSON.parse(podsJson);
+      for (const pod of pods.items || []) {
+        const podName = pod.metadata?.name;
+        const getName = (c: { name: string }) => c.name;
+        const containers = (pod.spec?.containers || []).map(getName);
+        const initContainers = (pod.spec?.initContainers || []).map(getName);
+        const ephemeralContainers = (pod.status?.ephemeralContainerStatuses || []).map(getName);
+
+        const groups: { names: string[]; suffix: string }[] = [
+          { names: containers, suffix: '' },
+          { names: initContainers, suffix: '.init' },
+          { names: ephemeralContainers, suffix: '.ephemeral' },
+        ];
+
+        for (const { names, suffix } of groups) {
+          for (const container of names) {
+            const logPrefix = `${podName}-${container}${suffix}`;
+            const current = safeOc([
+              'logs',
+              `pod/${podName}`,
+              '-c',
+              container,
+              '-n',
+              OLS_NAMESPACE,
+            ]);
+            if (current) {
+              fs.writeFileSync(path.join(podLogsDir, `${logPrefix}.log`), current);
+            }
+            const previous = safeOc([
+              'logs',
+              `pod/${podName}`,
+              '-c',
+              container,
+              '--previous',
+              '-n',
+              OLS_NAMESPACE,
+            ]);
+            if (previous) {
+              fs.writeFileSync(path.join(podLogsDir, `${logPrefix}.previous.log`), previous);
+            }
+          }
+        }
+      }
+    } catch (e: unknown) {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to parse pod JSON: ${e}`);
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`Cluster artifacts gathered in ${clusterDir}`);
+}
 
 export const interceptQuery = async (
   page: Page,

--- a/tests/support/global-teardown.ts
+++ b/tests/support/global-teardown.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { oc } from './fixtures';
+import { gatherClusterArtifacts, oc } from './fixtures';
 
 const globalTeardown = async () => {
   if (process.env.SKIP_OLS_SETUP) {
@@ -9,6 +9,13 @@ const globalTeardown = async () => {
 
   const OLS_NAMESPACE = 'openshift-lightspeed';
   const username = process.env.LOGIN_USERNAME || 'kubeadmin';
+
+  console.log('Gathering cluster artifacts...');
+  try {
+    gatherClusterArtifacts();
+  } catch {
+    // Ignore errors during artifact gathering
+  }
 
   try {
     oc(['delete', '--timeout=2m', 'OLSConfig', 'cluster']);

--- a/tests/support/global-teardown.ts
+++ b/tests/support/global-teardown.ts
@@ -11,11 +11,7 @@ const globalTeardown = async () => {
   const username = process.env.LOGIN_USERNAME || 'kubeadmin';
 
   console.log('Gathering cluster artifacts...');
-  try {
-    gatherClusterArtifacts();
-  } catch {
-    // Ignore errors during artifact gathering
-  }
+  gatherClusterArtifacts();
 
   try {
     oc(['delete', '--timeout=2m', 'OLSConfig', 'cluster']);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced test infrastructure to automatically gather cluster artifacts and pod logs after integration runs.
* **Tests**
  * CI pipeline now always exports and retains test artifacts at the end of runs to improve debugging and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->