### PR TITLE
OLS-3155: adding cluster claim 

### DIFF
--- a/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
+++ b/.tekton/integration-tests/lightspeed-console-pre-commit.yaml
@@ -37,68 +37,40 @@ spec:
           value: $(context.pipelineRun.name)
         - name: ownerUid
           value: $(context.pipelineRun.uid)
-    - name: provision-cluster
+    - name: provision-ephemeral-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/openshift/konflux-tasks
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name) # Internal usage only, use always this value here
+        - name: ownerUid
+          value: $(context.pipelineRun.uid) # Internal usage only, use always this value here
+        - name: workflow
+          value: generic-claim
+        - name: clusterClaim
+          value: |
+            {
+              "architecture": "amd64",
+              "cloud": "aws",
+              "labels": {
+                "region": "us-east-1",
+                "variant": "fips"
+              },
+              "owner": "obs",
+              "product": "ocp",
+              "timeout": "1h30m0s",
+              "version": "4.22"
+            }
       runAfter:
         - eaas-provision-space
         - lint
-      taskSpec:
-        results:
-          - name: clusterName
-            value: "$(steps.create-cluster.results.clusterName)"
-        steps:
-          - name: pick-version
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
-            params:
-              - name: prefix
-                value: "4.22."
-          - name: create-cluster
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: version
-                value: "$(steps.pick-version.results.version)"
-              - name: instanceType
-                value: "m5.xlarge"
-              - name: imageContentSources
-                value: |
-                  - source: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator
-                  - source: registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle
-                  - source: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service
-                  - source: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console
-                  - source: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5
-                  - source: registry.redhat.io/openshift-lightspeed/lightspeed-to-dataverse-exporter-rhel9
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-to-dataverse-exporter
-                  - source: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9
-                    mirrors:
-                      - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server
     - name: extract-snapshot-metadata
       description: Extract console image and commit from SNAPSHOT input
       runAfter:
@@ -174,12 +146,14 @@ spec:
       description: Task to run tests from service repository
       runAfter:
         - extract-snapshot-metadata
-        - provision-cluster
+        - provision-ephemeral-cluster
       params:
         - name: console-image
           value: $(tasks.extract-snapshot-metadata.results.console-image)
         - name: commit
           value: $(tasks.extract-snapshot-metadata.results.commit)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       taskSpec:
         volumes:
           - name: openai-token
@@ -193,24 +167,10 @@ spec:
         params:
           - name: console-image
           - name: commit
+          - name: clusterCredentialsSecretRef
+            type: string
+            description: "The secret that holds the cluster credentials"
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: run-e2e-tests
             onError: continue
             volumeMounts:
@@ -220,7 +180,12 @@ spec:
                 mountPath: /credentials
             env:
               - name: KUBECONFIG_PATH
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
+              - name: KUBECONFIG_VALUE
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.clusterCredentialsSecretRef)
+                    key: kubeconfig
               - name: LOGIN_IDP
                 value: "kube:admin"
               - name: LLM_TOKEN_PATH
@@ -229,17 +194,18 @@ spec:
                 value: "$(params.console-image)"
               - name: COMMIT_SHA
                 value: "$(params.commit)"
-              - name: PASSWORD_PATH
-                value: "/credentials/$(steps.get-kubeconfig.results.passwordPath)"
-              - name: BASE_URL
-                value: "$(steps.get-kubeconfig.results.consoleURL)"
+              - name: LOGIN_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.clusterCredentialsSecretRef)
+                    key: kubeAdminPassword
             resources:
               limits:
                 memory: 8Gi
             image: mcr.microsoft.com/playwright:v1.60.0-noble
             script: |
+              echo "$KUBECONFIG_VALUE" > /credentials/kubeconfig
               echo "COMMIT_SHA: ${COMMIT_SHA}"
-              echo "BASE_URL: ${BASE_URL}"
               echo "CONSOLE_IMAGE: ${CONSOLE_IMAGE}"
               echo "KUBECONFIG_PATH: ${KUBECONFIG_PATH}"
               echo "---------------------------------------------"
@@ -248,6 +214,8 @@ spec:
                   && chmod +x kubectl oc \
                   && mv oc kubectl /usr/local/bin/
               echo "---------------------------------------------"
+              export BASE_URL=https://$(oc --kubeconfig "$KUBECONFIG_PATH" get route console -n openshift-console -o go-template --template="{{.spec.host}}")
+              echo "BASE_URL: ${BASE_URL}"
               export OPERATOR_SDK_VERSION=1.36.1
               export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
               export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}
@@ -274,7 +242,6 @@ spec:
               echo "---------------------------------------------"
               NODE_OPTIONS=--max-old-space-size=4096 npm ci --omit=optional --no-fund
               echo "---------------------------------------------"
-              export LOGIN_PASSWORD=$(cat ${PASSWORD_PATH})
               set +e
               npx playwright test
               err_status=$?
@@ -300,7 +267,7 @@ spec:
               - name: credentials
                 value: "credentials"
               - name: kubeconfig
-                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "kubeconfig"
               - name: artifact-dir
                 value: "/workspace/artifacts/konflux-artifacts"
           # validate that the cluster resources are available in another tekton step
@@ -377,3 +344,18 @@ spec:
           value: "quay.io/openshift-lightspeed/ols-console-artifacts"
         - name: artifact-credentials-secret
           value: ols-konflux-artifacts-bot
+    - name: deprovision-ephemeral-cluster
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/openshift/konflux-tasks
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+      params:
+      - name: testPlatformClusterClaimName
+        value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimName)
+      - name: testPlatformClusterClaimNamespace
+        value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimNamespace)


### PR DESCRIPTION
and changing getting kubeconfig, base url and password

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched integration tests to ephemeral cluster provisioning and updated pipeline ordering to use the new provision/deprovision flow.
* **Tests**
  * Rewired end-to-end tests to receive cluster credentials (kubeconfig and admin password) via secrets; adjusted test startup and resource-gathering to use the new credential flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->