### PR TITLE
Add risk level rubric to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,7 @@ When finishing a development branch:
 2. Squash commits with the Jira-prefixed message
 3. Push to the contributor's fork remote (not `origin`)
 4. Create the PR against `origin/main` using `--head <user>:<branch>`
+
+## Risk Levels
+
+Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).


### PR DESCRIPTION
Adds a Risk Levels section to AGENTS.md defining risk 1/2/3 classification with repo-specific examples and Jira description format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with guidance on risk levels for Jira operations, including enforcement mechanisms and classification examples for ticket creation and editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->