### PR TITLE
4.19: Upgrade PatternFly Chatbot to 6.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@openshift-console/dynamic-plugin-sdk": "4.19.1",
         "@openshift-console/dynamic-plugin-sdk-webpack": "4.19.0",
-        "@patternfly/chatbot": "6.6.0-prerelease.6",
+        "@patternfly/chatbot": "6.6.0",
         "@patternfly/react-code-editor": "6.4.3",
         "@patternfly/react-core": "6.4.3",
         "@patternfly/react-icons": "6.4.0",
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/@patternfly/chatbot": {
-      "version": "6.6.0-prerelease.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/chatbot/-/chatbot-6.6.0-prerelease.6.tgz",
-      "integrity": "sha512-qv9ko6Wv1nxA8b7K03IkrEzoMxMPTrnJHqIW86h6NpcfASDhALjemNKZA5KUz0dDo4oJ3Sy+KJg0djDT46Ldpw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/chatbot/-/chatbot-6.6.0.tgz",
+      "integrity": "sha512-0JnhWD7K+vVmt71KzWWqPJf2q3jKj16zu0ZEoVxtmkSf3XNZJ8Mwt+bhPmrHgMroj9t/W31LsQHSxV0jju0Pvg==",
       "license": "MIT",
       "dependencies": {
         "@patternfly/react-code-editor": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@openshift-console/dynamic-plugin-sdk": "4.19.1",
     "@openshift-console/dynamic-plugin-sdk-webpack": "4.19.0",
-    "@patternfly/chatbot": "6.6.0-prerelease.6",
+    "@patternfly/chatbot": "6.6.0",
     "@patternfly/react-code-editor": "6.4.3",
     "@patternfly/react-core": "6.4.3",
     "@patternfly/react-icons": "6.4.0",


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/lightspeed-console/pull/2010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chatbot component library to the stable release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->