### PR TITLE
OLS-3256: Fix bug where the popover background was transparent on console latest

### DIFF
--- a/src/components/popover.css
+++ b/src/components/popover.css
@@ -14,6 +14,7 @@
 }
 
 .ols-plugin__popover {
+  background-color: var(--pf-t--global--background--color--primary--default);
   border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated popover component styling to include a default background color aligned with the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->