### PR TITLE
PF5: Upgrade react-router-dom-v5-compat to 6.30.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react-markdown": "^8.0.7",
         "react-modal": "^3.16.3",
         "react-redux": "7.2.2",
-        "react-router-dom-v5-compat": "^6.30.3",
+        "react-router-dom-v5-compat": "^6.30.4",
         "remark-gfm": "^3.0.1",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.7",
@@ -1690,9 +1690,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -9526,14 +9526,14 @@
       }
     },
     "node_modules/react-router-dom-v5-compat": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz",
-      "integrity": "sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.4.tgz",
+      "integrity": "sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
+        "@remix-run/router": "1.23.3",
         "history": "^5.3.0",
-        "react-router": "6.30.3"
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9553,12 +9553,12 @@
       }
     },
     "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-markdown": "^8.0.7",
     "react-modal": "^3.16.3",
     "react-redux": "7.2.2",
-    "react-router-dom-v5-compat": "^6.30.3",
+    "react-router-dom-v5-compat": "^6.30.4",
     "remark-gfm": "^3.0.1",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.7",


### PR DESCRIPTION
Manual backport of https://github.com/openshift/lightspeed-console/pull/2054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated router compatibility dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->