### PR TITLE
PF5: Increase wait until OLS load has completed

### DIFF
--- a/tests/support/global-setup.ts
+++ b/tests/support/global-setup.ts
@@ -292,13 +292,16 @@ spec:
   // After initial detection, wait for the page to stabilize (no further
   // reloads) by confirming the button remains present after a brief interval.
   // The console can reload multiple times after operator installation, so we
-  // wait until the button has been continuously visible for several checks.
-  const STABLE_THRESHOLD = 3;
+  // wait until the button has been continuously visible for a few consecutive
+  // checks before considering the page settled.
+  const LOAD_MAX_POLLS = 36;
+  const LOAD_POLL_INTERVAL = 10_000;
+  const LOAD_REQUIRED_POLLS = 12;
   let stableCount = 0;
-  for (let i = 0; i < 12; i++) {
-    await page.waitForTimeout(10_000);
+  for (let i = 0; i < LOAD_MAX_POLLS; i++) {
+    await page.waitForTimeout(LOAD_POLL_INTERVAL);
     if (await olsButton.isVisible().catch(() => false)) {
-      if (++stableCount >= STABLE_THRESHOLD) {
+      if (++stableCount >= LOAD_REQUIRED_POLLS) {
         break;
       }
       continue;


### PR DESCRIPTION
Manual backport of https://github.com/openshift/lightspeed-console/pull/2051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with enhanced page-load stabilization polling using tunable parameters for more reliable and consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->