### PR TITLE
OBSINTA-1383: send available tool UI IDs in chat request

### DIFF
--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -46,6 +46,7 @@ import { getFetchErrorMessage } from '../error';
 import { getRequestInitWithAuthHeader } from '../hooks/useAuth';
 import { useBoolean } from '../hooks/useBoolean';
 import { useLocationContext } from '../hooks/useLocationContext';
+import { useToolUIMapping } from '../hooks/useToolUIMapping';
 import { buildPageContext } from '../pageContext';
 import { alertingRuleID } from '../validation';
 import {
@@ -150,6 +151,8 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
 
   const location = useLocation();
   const [kind, name, namespace] = useLocationContext();
+  const [toolUIMapping, toolUIResolved] = useToolUIMapping();
+  const availableToolUIIDs = React.useMemo(() => Object.keys(toolUIMapping), [toolUIMapping]);
 
   const pageContext = React.useMemo(
     () => buildPageContext(kind, name, namespace),
@@ -627,6 +630,8 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
     const requestJSON = {
       attachments: attachments.valueSeq().map(toOLSAttachment),
       // eslint-disable-next-line camelcase
+      ...(toolUIResolved && { available_tool_ui_ids: availableToolUIIDs }),
+      // eslint-disable-next-line camelcase
       conversation_id: conversationID,
       // eslint-disable-next-line camelcase
       media_type: 'application/json',
@@ -810,6 +815,8 @@ const Prompt: React.FC<PromptProps> = ({ scrollIntoView }) => {
     textareaRef.current?.focus();
   }, [
     attachments,
+    availableToolUIIDs,
+    toolUIResolved,
     conversationID,
     dispatch,
     hidePrompt,


### PR DESCRIPTION
Include the list of available tool UI IDs in the OLS API request payload, resolved via the useToolUIMapping hook.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tool UI availability tracking by integrating tool UI mapping logic into the prompt component. The component now dynamically determines available tools and communicates this information more efficiently to the backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->