### PR TITLE
Tests: Skip OAuth when not available

### DIFF
--- a/tests/support/global-setup.ts
+++ b/tests/support/global-setup.ts
@@ -20,16 +20,20 @@ const globalSetup = async (config: FullConfig) => {
   oc(['adm', 'policy', 'add-cluster-role-to-user', 'cluster-admin', username]);
   oc(['adm', 'policy', 'add-cluster-role-to-user', 'lightspeed-operator-query-access', username]);
 
-  const oauthResult = oc([
-    'get',
-    'oauthclient',
-    'openshift-browser-client',
-    '-o',
-    'go-template',
-    '--template={{index .redirectURIs 0}}',
-  ]);
-  const oauthOrigin = new URL(oauthResult.trim().replace(/"/g, '')).origin;
-  console.log(`OAuth origin: ${oauthOrigin}`);
+  try {
+    const oauthResult = oc([
+      'get',
+      'oauthclient',
+      'openshift-browser-client',
+      '-o',
+      'go-template',
+      '--template={{index .redirectURIs 0}}',
+    ]);
+    const oauthOrigin = new URL(oauthResult.trim().replace(/"/g, '')).origin;
+    console.log(`OAuth origin: ${oauthOrigin}`);
+  } catch {
+    console.log('oauthclient not available on this cluster, skipping OAuth origin lookup');
+  }
 
   const OLS_NAMESPACE = 'openshift-lightspeed';
   const OLS_CONFIG_KIND = 'OLSConfig';


### PR DESCRIPTION
Extracted from https://github.com/openshift/lightspeed-console/pull/2023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup resilience by adding error handling for optional cluster resources. The global setup now gracefully skips unavailable resources with a logged message instead of failing the entire setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->